### PR TITLE
The demo exists now, and the workflow says otherwise

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,18 +8,24 @@ name: Deploy site
 # No secrets, no third-party account: the OIDC token below is issued by
 # GitHub to this workflow.
 #
-# NOT ENABLED TODAY, and it is not a toggle anyone forgot to flip: this repo is
-# private, and GitHub Pages does not serve a private repo on the free plan
-# (the API answers 422, "Your current plan does not support GitHub Pages").
-# Enabling it means making the repo public, or GitHub Pro, or hosting the demo
-# somewhere else — see the launch runway in docs/roadmap.md.
+# LIVE since 2026-08-22 at https://nourmtir0722.github.io/Paperlab/.
 #
-# Until then both jobs below skip themselves. They ran and failed on every
-# push from 2026-08-12 to 2026-08-13: the build always succeeded and
-# deploy-pages always 404'd, mailing a failure each time for a site that
-# cannot exist yet. The guard is `has_pages` rather than a disabled workflow
-# so that nobody has to remember this — enable Pages and the very next push
-# deploys, with no edit here.
+# The history is worth keeping, because it cost two wrong diagnoses. Pages
+# refused to serve while the repo was PRIVATE (the API answers 422, "Your
+# current plan does not support GitHub Pages"), and both jobs failed on every
+# push from 2026-08-12 to 2026-08-13 — build fine, deploy-pages 404 — mailing
+# a failure each time for a site that could not exist. That is what the
+# `has_pages` guard below is for.
+#
+# Going public was then necessary but NOT sufficient, which is the part that
+# surprised us: `has_pages` stayed false and this workflow reported `skipped`
+# on every push, because Pages itself still had to be switched on in
+# Settings → Pages → Source: "GitHub Actions". Once it was, the site had
+# still never built — this triggers on push, and there had been none since.
+# `gh workflow run pages.yml --ref main` deployed it in 46 seconds.
+#
+# So: the guard is a guard, not a disabled workflow, and `workflow_dispatch`
+# is the escape hatch for exactly the case above.
 #
 # On a custom domain (paperlab.dev), set BASE to '/' and add the CNAME step.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -151,7 +151,17 @@ be a code problem after all — see the npm entry.
         from a private repository. Provenance arrives free if the repo ever
         goes public, and not before.
 
-- [ ] **Turn on the demo — blocked, and not by the workflow.** `pages.yml` is
+- [x] **The demo is live — 2026-08-22.** https://nourmtir0722.github.io/Paperlab/
+      (playground), `/editor`, `/docs`. Two steps, and the second was the
+      surprise: making the repo public was **necessary but not sufficient**.
+      `has_pages` stayed false and the workflow reported `skipped` on every
+      push until Pages was switched on in Settings → Pages → Source: "GitHub
+      Actions". Even then nothing had built, because the workflow triggers on
+      push and there had been none since — `gh workflow run pages.yml --ref
+      main` deployed it in 46 seconds. The original entry, which was correct
+      about the cause and wrong about the remedy being one step, follows.
+
+  - [x] ~~**Turn on the demo — blocked, and not by the workflow.**~~ `pages.yml` is
       written and correct (playground at the root, editor at `/editor`, docs at
       `/docs`). **The repo is private, and GitHub Pages will not serve a private
       repo on the free plan** — the API refuses with "Your current plan does not


### PR DESCRIPTION
`pages.yml` opened with *"NOT ENABLED TODAY... this repo is private, and GitHub Pages does not serve a private repo on the free plan."* All three clauses are false as of today, on a public repo whose site is live — the worst kind of stale comment, because it is confident.

Kept the history rather than deleting it, because it cost two wrong diagnoses and the second is the useful one: **going public was necessary but not sufficient.** `has_pages` stayed false and the workflow reported `skipped` on every push until Pages was separately switched on in Settings → Pages → Source: "GitHub Actions". Even then nothing had built, because it triggers on push and there had been none since — `workflow_dispatch` is the escape hatch for exactly that case, and deployed in 46 seconds.

Same correction to the roadmap's launch runway entry.

Live: https://nourmtir0722.github.io/Paperlab/ · [/editor](https://nourmtir0722.github.io/Paperlab/editor/) · [/docs](https://nourmtir0722.github.io/Paperlab/docs/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)