### PR TITLE
The dry run could not see main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,15 @@ jobs:
           fi
           echo
           echo "--- what would be released ---"
-          pnpm exec changeset status
+          # `changeset status` diffs against main, and `actions/checkout`
+          # clones one branch at depth 1 — so on any branch but main, main
+          # simply is not there and it fails with "Failed to find where HEAD
+          # diverged". Fetch it. Non-fatal on purpose: the version assertions
+          # above are the gate, and a dry run that fails for a reason
+          # unrelated to the release is a dry run nobody will trust.
+          git fetch --no-tags --depth=50 origin main:refs/remotes/origin/main 2>/dev/null || true
+          pnpm exec changeset status --since=origin/main \
+            || echo "(could not compute — the assertions above are the gate)"
 
       # No NPM_TOKEN: npm authenticates this workflow via OIDC, configured as a
       # trusted publisher on the package. Provenance should now arrive on its


### PR DESCRIPTION
Caught by the first thing the dry run was pointed at — which is the outcome you want from a new check, even when the check is what breaks.

`changeset status` diffs against `main` to work out what would be released, and `actions/checkout` clones a single branch at depth 1. So on any branch other than main, main is not in the repository at all, and changesets fails with *"Failed to find where HEAD diverged"*. Nothing to do with the release.

Fetches main first, and the status is **non-fatal** now. The version assertions above it are the gate — a dry run that fails for a reason unrelated to the release is one nobody will trust, and an untrusted check is worse than no check because it teaches people to ignore a red mark.

## What the run proved before it tripped

```
node    v22.23.2
npm     11.19.0    ← the load-bearing pin holds
pnpm    9.15.0     ← matches packageManager: pnpm@9.15.0 exactly
```

…under `checkout@v7`, `setup-node@v7` and `pnpm/action-setup@v6`. Which is exactly the question #25 needed answered, and the answer is that the bump is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)