### PR TITLE
changesets/action v2, and the migration it needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -102,7 +102,7 @@ jobs:
           # .nojekyll keeps Pages from eating asset dirs that start with _.
           touch site/.nojekyll
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -118,4 +118,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Full history. `changeset status` finds what would be released by
+      # merge-basing against main, and merge-base does not work in a shallow
+      # clone — fetching main afterwards is not enough either, because the
+      # grafted history has no common ancestor to find. This repo is under a
+      # hundred commits; the clone costs nothing.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
 
@@ -88,13 +95,11 @@ jobs:
           fi
           echo
           echo "--- what would be released ---"
-          # `changeset status` diffs against main, and `actions/checkout`
-          # clones one branch at depth 1 — so on any branch but main, main
-          # simply is not there and it fails with "Failed to find where HEAD
-          # diverged". Fetch it. Non-fatal on purpose: the version assertions
-          # above are the gate, and a dry run that fails for a reason
-          # unrelated to the release is a dry run nobody will trust.
-          git fetch --no-tags --depth=50 origin main:refs/remotes/origin/main 2>/dev/null || true
+          # Needs the full clone above: this merge-bases against main, and
+          # merge-base cannot work in a shallow one. Still non-fatal — the
+          # version assertions are the gate, and a dry run that goes red for
+          # a reason unrelated to the release is one nobody will trust.
+          git fetch --no-tags origin main:refs/remotes/origin/main 2>/dev/null || true
           pnpm exec changeset status --since=origin/main \
             || echo "(could not compute — the assertions above are the gate)"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -102,10 +102,25 @@ jobs:
       # trusted publisher on the package. Provenance should now arrive on its
       # own — npm would not attest a build from a private repo, which is why
       # 0.2.0 carries no attestations, and this repo went public 2026-08-21.
+      # changesets/action v2 RENAMED its inputs, and the old names are not
+      # aliased — they are simply unrecognised. Taking the bump without this
+      # migration would have opened the version PR and then quietly never
+      # published, with a green check on the run, which is the same shape of
+      # silent half-release that cost 0.1.0.
+      #
+      #   publish  -> publish-script
+      #
+      # v2 also stopped accepting the token from the environment: "custom
+      # GitHub tokens must be passed explicitly through the `github-token`
+      # input. The GITHUB_TOKEN environment variable and credentials
+      # configured by actions/checkout are not substitutes for this input."
+      # The env var below stays because `changeset publish` itself still
+      # reads it; the input is what the action needs.
       - name: Create release PR or publish to npm
         if: github.event_name == 'push' || inputs.publish
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          publish: pnpm exec changeset publish
+          publish-script: pnpm exec changeset publish
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Supersedes #28. Dependabot's grouped bump quietly grew a sixth entry — **changesets/action v1 → v2** — and taken as-is it would have broken the release in two ways, with **CI green for both**, because CI never runs `release.yml`.

## What v2 breaks here

**1. The inputs were renamed, and the old names are not aliased.** `publish` is now `publish-script`; the old name is simply unrecognised. The action would have opened the version PR and then *never published* — a silent half-release, the exact shape of the failure that cost `0.1.0`.

**2. The token is no longer read from the environment.** From the v2 notes:

> custom GitHub tokens must be passed explicitly through the `github-token` input. The `GITHUB_TOKEN` environment variable and credentials configured by `actions/checkout` … are not substitutes for this input.

The workflow passed it only as `env`.

Both fixed here alongside the bump, because a rename and its migration are one change — they land together or not at all.

## The other five

`checkout@v7`, `setup-node@v7`, `pnpm/action-setup@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5` — validated by dispatching the new release dry run **from the bump's own branch**, which runs the real release path:

```
node    v22.23.2
npm     11.19.0    ← the pin holds
pnpm    9.15.0     ← matches packageManager exactly
```

`pnpm/action-setup` was the one worth checking, since it is used with no `version` input and resolves from that field.

## The gap, stated plainly

The dry run **could not** have caught the changesets break, because it deliberately stops before the publish step. Reading the release notes was the only way to close that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)