### PR TITLE
Match the biome schema to the biome doing the checking

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
The grouped npm bump moved the biome CLI to 2.5.9 and left `biome.json` declaring the 2.5.6 schema, so every `pnpm lint` since has printed a version-mismatch info.

It is only an info and CI stays green — which is exactly why it is worth fixing now rather than later. A lint that always prints something teaches people to skim past its output, and the next real finding then arrives into an audience that has stopped reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)