### PR TITLE
fix(paperlab): a schema is a contract in both directions

### DIFF
--- a/.changeset/a-schema-is-a-contract-both-ways.md
+++ b/.changeset/a-schema-is-a-contract-both-ways.md
@@ -1,0 +1,35 @@
+---
+"paperlab": patch
+---
+
+Four crashes, one shape: a value reaching a strict parse from inside a render.
+
+The report was "when I interact with anything the whole app freezes", then "whenever I try to manage speed the app gets closed". Both were real, neither was what it sounded like, and the second one turned out to be a class rather than a bug.
+
+### The freeze: a notification that had become a pump
+
+`<PaperStageScene>` reported its settled quality tier from an effect that named the callback in its own dependency list. The natural way to pass that prop is an inline arrow, which is a new function on every render of the page above — so the effect fired on every **consumer render**, not on every tier change. The consumer stores the tier, which re-renders, which makes another arrow, which fires the effect again.
+
+Measured at ~6 App renders a second at rest in stage mode, each one a full `stageSchema.parse` and walk resample. That is why every interaction felt frozen, and why dragging the scrubber could take the tab out with an out-of-memory crash. The callback now lives in a ref and the effect depends on `tier` alone.
+
+The general rule, since it is not specific to this prop: **a callback prop is a notification, not a dependency.** If an effect exists to tell the consumer something, it depends on the thing being told and reaches the callback through a ref.
+
+### The crash: `.int()`, and everywhere else the same shape hid
+
+The editor's generated sliders took two facts off a schema — `min` and `max` — and derived a step of `(max - min) / 200`. They never read `.int()`. So touching `seed` on a colonnade wrote `2.5` into a field declared `z.number().int()`, and `<PaperStageScene>` re-parses its layout options **during render** to place the walk's stops. A strict parse does not warn about a fraction; it throws, inside a render, which unmounts the tree.
+
+Ten fields across the library carry `.int()`. Fixed once, in the control model: an int field gets `step: 1` **and** its emitted value is rounded, because the readout you can type into clamps but never snaps.
+
+Asking where else that shape hid found three more:
+
+- **A second copy of the schema walk** in the editor's states bar, missing `.int()` in exactly the same way, crashing through a different parse (`resolveFieldSlotConfig`, also during render). Fixed by deleting the copy — there is now one reader of a `z.ZodNumber`.
+- **Exclusive bounds.** `.positive()` is stored as `min: 0, inclusive: false` — one boolean away from `.min(0)` — and reading the value while dropping the boolean gives a slider whose end is the one number the schema rejects. Latent; handled anyway.
+- **The same shape on the text side, and live.** A stage's sky colours are text fields, and a text field emits per keystroke, so the library is handed `#f` and `#ff` while somebody types `#ffaa22`. `addColorStop` is one of the few canvas calls that *throws* rather than ignoring what it cannot parse, and the sky is built during render. Three.js is the forgiving one, which is why the gradient was the only path that broke. `cssColorOr` now asks a canvas whether a string is a colour — the canvas's own opinion rather than a regex, because CSS colours are a larger set than a regex should be trusted with.
+
+The rule worth keeping: **a schema is a contract in both directions.** Anything generated from one has to emit what that schema accepts, because the code receiving it is entitled to parse strictly — and a strict parse inside a render is an app-level crash, not a validation message.
+
+### Also: dependency arrays are evaluated every render
+
+`PaperFieldMesh`, `FitCamera`, `useContentAtlas` and the resolved-config memo all used `JSON.stringify` as a memo dependency. A dependency array is evaluated on **every** render, so the serialization was paid every render whether or not anything changed — and paid in garbage rather than in time. A field of fourteen photographs re-serialized roughly seventeen megabytes per render, because an image slot carries its bitmap inline as a data URL.
+
+Replaced with `useStable`, a deep compare that allocates nothing and short-circuits on `Object.is` at every level, so the common case — a fresh wrapper around the same inner objects — costs a handful of pointer checks however large the data URL underneath.

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -48,6 +48,13 @@ import { useEditor, zoneToConfig } from './store'
  */
 const FIGURE_MODEL = `${import.meta.env.BASE_URL}figure/walking-figure.glb`
 
+/**
+ * What a field slot falls back to when the preset it names is gone. The same
+ * built-in `deletePreset` and the session sanitizer already fall back to, so
+ * a missing preset lands in one place however it went missing.
+ */
+const FALLBACK_PRESET = 'photo-print'
+
 export function App() {
   const presetName = useEditor((s) => s.presetName)
   const importSharedPaper = useEditor((s) => s.importSharedPaper)
@@ -97,7 +104,19 @@ export function App() {
   }, [importSharedPaper, setMode])
 
   // Presets are components: the field renders the live edit of its preset.
-  const resolvePresetByName = (name: string): PaperConfig => (name === presetName ? config : getPreset(name))
+  // `getPreset` THROWS on a name it does not know, and this runs for every
+  // field slot on every render — so one stale slot name (a preset deleted in
+  // another tab, a session written by a build that had it) would take the
+  // whole editor down rather than one paper. Fall back to a built-in: a
+  // wrong-looking sheet is a bug report, a blank page is not.
+  const resolvePresetByName = (name: string): PaperConfig => {
+    if (name === presetName) return config
+    try {
+      return getPreset(name)
+    } catch {
+      return getPreset(FALLBACK_PRESET)
+    }
+  }
   // Every slot gets a DIFFERENT card, so fourteen sheets read as a drawer of
   // records rather than as one card printed fourteen times.
   const slotContent = (i: number): ContentConfigInput =>

--- a/apps/editor/src/CrashScreen.tsx
+++ b/apps/editor/src/CrashScreen.tsx
@@ -1,0 +1,79 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { clearSession } from './session'
+
+/**
+ * The editor's error boundary.
+ *
+ * React unmounts the entire tree when a render throws and nothing catches
+ * it, so until now every error in this app — a preset that isn't registered,
+ * a stored view a newer build wrote, anything at all — showed up as a **blank
+ * white page**. No message, no stack, nothing to report, and reloading walked
+ * straight back into it if the cause was persisted.
+ *
+ * A tool is allowed to break. It is not allowed to disappear. This catches
+ * the throw, keeps the error on screen where it can be read and copied, and
+ * offers the two ways out that actually work: reload, or forget the
+ * remembered session first and then reload — which is the escape hatch when
+ * the thing being restored is itself what breaks.
+ */
+interface State {
+  error: Error | null
+  info: ErrorInfo | null
+}
+
+export class CrashScreen extends Component<{ children: ReactNode }, State> {
+  state: State = { error: null, info: null }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.setState({ info })
+    // Still log it: the console keeps the full stack and the source maps,
+    // which is more than any panel should try to reproduce.
+    console.error('[paperlab] the editor crashed', error, info.componentStack)
+  }
+
+  render() {
+    const { error, info } = this.state
+    if (!error) return this.props.children
+
+    const report = [
+      error.stack ?? `${error.name}: ${error.message}`,
+      info?.componentStack ? `\nComponent stack:${info.componentStack}` : '',
+    ].join('')
+
+    return (
+      <div className="crash">
+        <div className="crash-panel">
+          <h1>The editor hit an error</h1>
+          <p className="crash-message">{error.message || String(error)}</p>
+          <p className="crash-hint">
+            Your saved presets are safe — they live separately from the view that broke. If this happens again
+            the moment you reload, the remembered session is the likely cause; forget it and you'll come back
+            up on the default paper.
+          </p>
+          <div className="crash-actions">
+            <button type="button" onClick={() => window.location.reload()}>
+              Reload
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                clearSession()
+                window.location.reload()
+              }}
+            >
+              Forget the session and reload
+            </button>
+            <button type="button" onClick={() => void navigator.clipboard?.writeText(report)}>
+              Copy error
+            </button>
+          </div>
+          <pre className="crash-stack">{report}</pre>
+        </div>
+      </div>
+    )
+  }
+}

--- a/apps/editor/src/StatesBar.tsx
+++ b/apps/editor/src/StatesBar.tsx
@@ -7,6 +7,7 @@ import {
   type PaperConfig,
   type StateDef,
 } from 'paperlab'
+import { numericFields } from './controlModel'
 import { useEditor } from './store'
 
 /**
@@ -243,33 +244,29 @@ function SlotStateControls({
     (field.slotStates[slot]?.states?.[state]?.overrides as { behavior?: Record<string, unknown> })
       ?.behavior ?? {}
 
-  const controls: React.ReactNode[] = []
-  for (const [key, fieldSchema] of Object.entries(schema.shape as Record<string, z.ZodTypeAny>)) {
-    let inner = fieldSchema
-    while (inner instanceof z.ZodDefault || inner instanceof z.ZodOptional) {
-      inner = inner instanceof z.ZodDefault ? inner._def.innerType : inner.unwrap()
-    }
-    if (!(inner instanceof z.ZodNumber)) continue
-    const min = inner._def.checks.find((c) => c.kind === 'min')
-    const max = inner._def.checks.find((c) => c.kind === 'max')
-    const lo = min && 'value' in min ? min.value : 0
-    const hi = max && 'value' in max ? max.value : 1
+  // The range, step and rounding come from `numericFields`, NOT from a
+  // second reading of the schema here. This panel used to do its own — and
+  // was missing `.int()`, so dragging `seed` on a crumple slot wrote a
+  // fraction into the slot's overrides, which `resolveFieldSlotConfig`
+  // re-parses during render. Same uncaught ZodError, same blank editor, in a
+  // second place. One reader now, so there is no second copy to forget.
+  const controls = numericFields(schema).map(({ key, spec }) => {
     const value =
       (slotOverrides[key] as number | undefined) ??
       ((stateView.behavior as Record<string, unknown>)[key] as number)
-    controls.push(
+    return (
       <label key={key} className="slot-state-control">
         {key}
         <input
           type="range"
-          min={lo}
-          max={hi}
-          step={(hi - lo) / 200}
+          min={spec.min}
+          max={spec.max}
+          step={spec.step}
           defaultValue={value}
-          onChange={(e) => onPatch({ behavior: { [key]: Number(e.target.value) } })}
+          onChange={(e) => onPatch({ behavior: { [key]: spec.snap(Number(e.target.value)) } })}
         />
-      </label>,
+      </label>
     )
-  }
+  })
   return <>{controls}</>
 }

--- a/apps/editor/src/controlModel.test.ts
+++ b/apps/editor/src/controlModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { schemaControls, type Control } from './controlModel'
+import { numberSpec, numericFields, schemaControls, type Control } from './controlModel'
 
 const byKey = (controls: Control[], key: string) => {
   const found = controls.find((c) => c.key === key)
@@ -132,5 +132,140 @@ describe('schemaControls', () => {
 
   it('returns nothing for a non-object schema', () => {
     expect(schemaControls(z.number(), {}, () => {})).toEqual([])
+  })
+})
+
+/**
+ * Integer fields, and the crash that made them worth a block of their own.
+ *
+ * A generated slider used to take only min and max off the schema and derive
+ * its step as `(max - min) / 200`. For a `z.number().int()` field that is a
+ * fraction, and the receiving parse does not warn about a fraction — it
+ * THROWS. `<PaperStageScene>` re-parses its layout options during render, so
+ * dragging `seed` on a colonnade raised an uncaught ZodError inside a render
+ * and React unmounted the entire editor: a blank white page, no message.
+ *
+ * Ten fields across the library carry `.int()` — `seed` on four layouts and
+ * on crumple, `rows`/`columns` on the sheet grid, `columns` on the rack,
+ * `segments` on the sheet — so this is one control-model rule standing in
+ * front of all of them.
+ */
+describe('schemaControls with integer fields', () => {
+  const seedSchema = z.object({ seed: z.number().int().min(0).max(9999).default(2) })
+
+  it('steps an int field by 1 instead of by a two-hundredth of its range', () => {
+    const [ctl] = schemaControls(seedSchema, { seed: 2 }, () => {})
+    if (ctl?.kind !== 'number') throw new Error('expected number')
+    expect(ctl.step).toBe(1)
+  })
+
+  it('never emits a fraction, whatever the slider hands it', () => {
+    const seen: unknown[] = []
+    const [ctl] = schemaControls(seedSchema, { seed: 2 }, (_key, v) => seen.push(v))
+    if (ctl?.kind !== 'number') throw new Error('expected number')
+    // The typed-value path clamps but does not snap, so the control itself
+    // has to be the thing that rounds.
+    for (const raw of [2.5, 0.1, 3.7, 9998.6, -0.4]) ctl.onChange(raw)
+    expect(seen).toEqual([3, 0, 4, 9999, -0])
+    for (const v of seen) expect(Number.isInteger(v as number)).toBe(true)
+  })
+
+  it('emits values the schema actually accepts — the parse that used to throw', () => {
+    const [ctl] = schemaControls(seedSchema, { seed: 2 }, (_k, v) => {
+      expect(() => seedSchema.parse({ seed: v })).not.toThrow()
+    })
+    if (ctl?.kind !== 'number') throw new Error('expected number')
+    for (let raw = 0; raw <= 12; raw += 0.37) ctl.onChange(raw)
+  })
+
+  it('leaves a plain float field alone', () => {
+    const [ctl] = schemaControls(z.object({ hover: z.number().min(0).max(2) }), { hover: 1 }, () => {})
+    if (ctl?.kind !== 'number') throw new Error('expected number')
+    expect(ctl.step).toBeCloseTo(2 / 200)
+  })
+
+  it('applies to an int inside a numeric tuple too', () => {
+    const seen: unknown[] = []
+    const schema = z.object({ cell: z.tuple([z.number().int().min(1).max(9), z.number().min(0).max(1)]) })
+    const controls = schemaControls(schema, { cell: [2, 0.5] }, (_k, v) => seen.push(v))
+    const first = byKey(controls, 'cellX')
+    const second = byKey(controls, 'cellY')
+    if (first.kind !== 'number' || second.kind !== 'number') throw new Error('expected numbers')
+    expect(first.step).toBe(1)
+    expect(second.step).toBeCloseTo(1 / 200)
+    first.onChange(4.6)
+    expect(seen).toEqual([[5, 0.5]])
+  })
+})
+
+/**
+ * `numberSpec` is the single reader of a numeric zod field, and
+ * `numericFields` is how a panel that draws its own markup gets at it
+ * without writing a second one. `StatesBar` did write a second one, it was
+ * missing `.int()`, and that shipped the identical crash in a second place —
+ * so these guard the reader itself rather than any one panel.
+ */
+describe('numberSpec', () => {
+  it('keeps an exclusive bound off the track', () => {
+    // `.positive()` is stored as min 0 with inclusive:false — one boolean
+    // apart from `.min(0)`, and the difference is whether the far end of the
+    // slider is a number the schema throws on.
+    const schema = z.number().positive().max(20)
+    const spec = numberSpec(schema)
+    expect(spec.min).toBeGreaterThan(0)
+    expect(() => schema.parse(spec.snap(spec.min))).not.toThrow()
+    expect(() => schema.parse(spec.snap(spec.max))).not.toThrow()
+  })
+
+  it('leaves an inclusive bound exactly where the schema put it', () => {
+    const spec = numberSpec(z.number().min(0).max(2))
+    expect(spec.min).toBe(0)
+    expect(spec.max).toBe(2)
+  })
+
+  it('emits only values the schema accepts, across every numeric field in the app', () => {
+    // The property that actually matters, stated once over a table of the
+    // shapes the library really uses.
+    const schemas: z.ZodNumber[] = [
+      z.number().int().min(0).max(9999),
+      z.number().int().min(0).max(7),
+      z.number().int().min(1).max(24),
+      z.number().int().min(2).max(256),
+      z.number().positive().max(20),
+      z.number().min(0.2).max(3),
+      z.number().min(-1).max(1),
+      z.number(),
+    ]
+    for (const schema of schemas) {
+      const spec = numberSpec(schema)
+      // Walk the track the way a drag does, plus both endpoints exactly.
+      const samples = [spec.min, spec.max]
+      for (let k = 0; k <= 40; k++) samples.push(spec.min + ((spec.max - spec.min) * k) / 40)
+      for (const raw of samples) {
+        const emitted = spec.snap(raw)
+        expect(
+          () => schema.parse(emitted),
+          `${JSON.stringify(schema._def.checks)} rejected ${emitted} (from ${raw})`,
+        ).not.toThrow()
+      }
+    }
+  })
+})
+
+describe('numericFields', () => {
+  it('reports every numeric field of a behavior schema, unwrapping defaults', () => {
+    const schema = z.object({
+      progress: z.number().min(0).max(1).default(0),
+      seed: z.number().int().min(0).max(7).default(0),
+      corner: z.enum(['a', 'b']),
+    })
+    const fields = numericFields(schema)
+    expect(fields.map((f) => f.key)).toEqual(['progress', 'seed'])
+    expect(fields.find((f) => f.key === 'seed')?.spec.step).toBe(1)
+    expect(fields.find((f) => f.key === 'seed')?.spec.snap(2.5)).toBe(3)
+  })
+
+  it('returns nothing for a non-object schema', () => {
+    expect(numericFields(z.number())).toEqual([])
   })
 })

--- a/apps/editor/src/controlModel.ts
+++ b/apps/editor/src/controlModel.ts
@@ -135,26 +135,24 @@ export function schemaControls(
     const value = values[key]
 
     if (inner instanceof z.ZodNumber) {
-      const min = checkValue(inner, 'min') ?? 0
-      const max = checkValue(inner, 'max') ?? 1
-      controls.push(num(key, typeof value === 'number' ? value : min, { min, max }, (v) => onChange(key, v)))
+      controls.push(numberControl(key, key, inner, value, (v) => onChange(key, v)))
     } else if (inner instanceof z.ZodTuple && isNumberTuple(inner)) {
       // Numeric tuples (flight's wind vector) → one slider per component.
       const items = inner._def.items as z.ZodNumber[]
       const current = Array.isArray(value) ? (value as number[]) : items.map(() => 0)
       items.forEach((item, axis) => {
-        const min = checkValue(item, 'min') ?? -1
-        const max = checkValue(item, 'max') ?? 1
         controls.push(
-          num(
+          numberControl(
             `${key}${'XYZW'[axis] ?? axis}`,
+            `${key} ${'xyzw'[axis] ?? axis}`,
+            item,
             current[axis] ?? 0,
-            { min, max, label: `${key} ${'xyzw'[axis] ?? axis}` },
             (v) => {
               const next = [...current]
               next[axis] = v
               onChange(key, next)
             },
+            { fallbackMin: -1 },
           ),
         )
       })
@@ -173,6 +171,87 @@ export function schemaControls(
     }
   }
   return controls
+}
+
+/**
+ * What a numeric zod field permits, in the terms a slider needs.
+ *
+ * **This is the one place that reads a `z.ZodNumber`.** It exists because
+ * the same reading was once done twice — here and by hand in `StatesBar` —
+ * and the copy that was written second was missing a check, which is a
+ * completely avoidable way to ship the same crash twice.
+ *
+ * The checks that matter, and why:
+ *
+ * - **`.int()`.** A step of `(max - min) / 200` on an integer field hands
+ *   the schema a fraction the moment you touch it, and the receiving parse
+ *   does not warn — it THROWS. Dragging `seed` on a colonnade took the whole
+ *   editor down that way: `<PaperStageScene>` re-parses its layout options
+ *   during render, so a 2.5 became an uncaught ZodError inside a render and
+ *   React unmounted everything. `snap` rounds as well as stepping, because
+ *   the readout you can type into clamps but never snaps.
+ * - **Exclusive bounds.** `.positive()` is stored as `min: 0, inclusive:
+ *   false` — the same shape as `.min(0)`, one boolean apart. Reading the
+ *   value and ignoring the boolean gives a slider whose far end is the one
+ *   number the schema rejects. Shifted by a step so the track cannot land
+ *   on it.
+ */
+export interface NumberSpec {
+  min: number
+  max: number
+  step: number
+  /** Coerce a raw slider/typed value into something the schema accepts. */
+  snap: (v: number) => number
+}
+
+export function numberSpec(schema: z.ZodNumber, fallbackMin = 0): NumberSpec {
+  const integer = schema._def.checks.some((c) => c.kind === 'int')
+  const rawMin = checkValue(schema, 'min') ?? fallbackMin
+  const rawMax = checkValue(schema, 'max') ?? 1
+  const step = integer ? 1 : (rawMax - rawMin) / 200
+  // An excluded endpoint is still a number the track could land on; move the
+  // end in by one step so it cannot.
+  const min = isExclusive(schema, 'min') ? rawMin + step : rawMin
+  const max = isExclusive(schema, 'max') ? rawMax - step : rawMax
+  return { min, max, step, snap: integer ? (v) => Math.round(v) : (v) => v }
+}
+
+/** One slider for one numeric schema field, on the spec above. */
+function numberControl(
+  key: string,
+  label: string,
+  schema: z.ZodNumber,
+  value: unknown,
+  onChange: (v: number) => void,
+  opts: { fallbackMin?: number } = {},
+): Control {
+  const spec = numberSpec(schema, opts.fallbackMin)
+  return num(
+    key,
+    typeof value === 'number' ? value : spec.min,
+    { min: spec.min, max: spec.max, step: spec.step, label },
+    (v) => onChange(spec.snap(v)),
+  )
+}
+
+/**
+ * Every numeric field of an object schema, with its spec. For panels that
+ * draw their own markup rather than going through `Control` — they still do
+ * not get to re-derive what the schema allows.
+ */
+export function numericFields(schema: z.ZodTypeAny): { key: string; spec: NumberSpec }[] {
+  if (!(schema instanceof z.ZodObject)) return []
+  const out: { key: string; spec: NumberSpec }[] = []
+  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodTypeAny>)) {
+    const inner = unwrap(field)
+    if (inner instanceof z.ZodNumber) out.push({ key, spec: numberSpec(inner) })
+  }
+  return out
+}
+
+function isExclusive(schema: z.ZodNumber, kind: 'min' | 'max'): boolean {
+  const check = schema._def.checks.find((c) => c.kind === kind)
+  return Boolean(check && 'inclusive' in check && check.inclusive === false)
 }
 
 function isNumberTuple(tuple: z.ZodTuple): boolean {

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
+import { CrashScreen } from './CrashScreen'
 import { startSessionMemory } from './session'
 import { useEditor } from './store'
 import './styles.css'
@@ -7,4 +8,10 @@ import './styles.css'
 // The store restores the last session on import; this keeps it current.
 startSessionMemory(useEditor)
 
-createRoot(document.getElementById('root')!).render(<App />)
+// Wrapped, because a render error with nothing to catch it unmounts the
+// whole tree and leaves a blank page — see CrashScreen.
+createRoot(document.getElementById('root')!).render(
+  <CrashScreen>
+    <App />
+  </CrashScreen>,
+)

--- a/apps/editor/src/session.ts
+++ b/apps/editor/src/session.ts
@@ -30,6 +30,22 @@ import type { EditorMode, EditorZone, FieldState, StageState } from './store'
 
 const STORAGE_KEY = 'paperlab.session.v1'
 
+/**
+ * Forget the remembered view.
+ *
+ * The session is a convenience that is allowed to fail, and the failure that
+ * matters is a stored view this build cannot render — reloading would just
+ * restore it and break again. The crash screen offers this so there is a way
+ * back that does not involve knowing what localStorage is.
+ */
+export function clearSession(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* nothing to clear, or no storage at all — reloading is still worth a try */
+  }
+}
+
 /** Long enough to outlast a slider drag, short enough to survive a tab close. */
 const WRITE_DEBOUNCE_MS = 500
 

--- a/apps/editor/src/store.test.ts
+++ b/apps/editor/src/store.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { useEditor } from './store'
+
+/**
+ * The stage store, and the one property that keeps the scene from pumping
+ * itself.
+ *
+ * `<PaperStageScene>` reports back up here — the quality tier it settled on,
+ * every time it settles. If a report that says nothing new still produces a
+ * fresh `stage` object, zustand notifies, the app re-renders, the scene is
+ * handed new prop identities, and it reports again: a loop that spends every
+ * frame on itself and leaves nothing for the interaction you actually made.
+ * That is what "the whole app freezes when I touch anything" looked like.
+ *
+ * So the guarantee under test is identity, not equality: an unchanged patch
+ * must return the SAME object, because that is the only thing a subscriber
+ * checks.
+ */
+describe('patchStage', () => {
+  it('returns the same stage object when the patch changes nothing', () => {
+    const before = useEditor.getState().stage
+    useEditor.getState().patchStage({ settled: before.settled })
+    expect(useEditor.getState().stage).toBe(before)
+  })
+
+  it('is a no-op for a repeated report, however many times it arrives', () => {
+    useEditor.getState().patchStage({ settled: 'medium' })
+    const settledOnce = useEditor.getState().stage
+    for (let i = 0; i < 5; i++) useEditor.getState().patchStage({ settled: 'medium' })
+    expect(useEditor.getState().stage).toBe(settledOnce)
+  })
+
+  it('still writes a patch that does change something', () => {
+    const before = useEditor.getState().stage
+    useEditor.getState().patchStage({ progress: before.progress + 0.1 })
+    const after = useEditor.getState().stage
+    expect(after).not.toBe(before)
+    expect(after.progress).toBeCloseTo(before.progress + 0.1)
+  })
+
+  it('writes when only one key of a multi-key patch is new', () => {
+    const before = useEditor.getState().stage
+    useEditor.getState().patchStage({ settled: before.settled, playing: !before.playing })
+    expect(useEditor.getState().stage.playing).toBe(!before.playing)
+  })
+})

--- a/apps/editor/src/store.ts
+++ b/apps/editor/src/store.ts
@@ -399,7 +399,16 @@ export const useEditor = create<EditorState>((set, get) => ({
       selectedSlot: null,
       inspectorEpoch: s.inspectorEpoch + 1,
     })),
-  patchStage: (patch) => set((s) => ({ stage: { ...s.stage, ...patch } })),
+  // A patch that changes nothing returns the SAME stage object, so it does
+  // not notify. The scene reports things back up here every time it settles
+  // — the quality tier most of all — and a store that hands out a fresh
+  // object for a no-op turns each of those reports into a re-render, which
+  // is exactly the loop that made stage mode unusable.
+  patchStage: (patch) =>
+    set((s) => {
+      const changed = Object.entries(patch).some(([key, value]) => s.stage[key as keyof StageState] !== value)
+      return changed ? { stage: { ...s.stage, ...patch } } : s
+    }),
   loadStagePreset: (id) =>
     set((s) => ({
       // A preset replaces the stage wholesale rather than merging: half of

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1154,3 +1154,88 @@ button.export:hover {
   line-height: 1.5;
   padding: 4px 0 6px;
 }
+
+/* ── Crash screen ────────────────────────────────────────────────────────
+   Shown by the error boundary in place of the blank page a thrown render
+   used to leave behind. Deliberately plain: it has to render correctly when
+   the thing that broke might be anything else in the app. */
+.crash {
+  position: fixed;
+  inset: 0;
+  overflow: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 6vh 24px;
+  background: #17181b;
+  color: #e7e7ea;
+  font:
+    13px / 1.55 ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+.crash-panel {
+  width: min(760px, 100%);
+}
+
+.crash h1 {
+  margin: 0 0 12px;
+  font-size: 19px;
+  font-weight: 600;
+}
+
+.crash-message {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-left: 2px solid #d9534f;
+  background: #1e1f23;
+  color: #ffb4b1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-word;
+}
+
+.crash-hint {
+  margin: 0 0 18px;
+  color: #9a9aa2;
+}
+
+.crash-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.crash-actions button {
+  padding: 7px 13px;
+  border: 1px solid #35363c;
+  border-radius: 6px;
+  background: #232429;
+  color: #e7e7ea;
+  font: inherit;
+  cursor: pointer;
+}
+
+.crash-actions button:hover {
+  background: #2c2d33;
+  border-color: #45464e;
+}
+
+.crash-stack {
+  margin: 0;
+  padding: 12px;
+  max-height: 46vh;
+  overflow: auto;
+  border: 1px solid #26272c;
+  border-radius: 6px;
+  background: #121316;
+  color: #8f9098;
+  font:
+    11px / 1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -240,6 +240,178 @@ status.
 
 ---
 
+## A generated slider handed an integer field a fraction — *fixed*
+
+**Reported 2026-08-22 as "the app gets closed". It was a blank white page,
+and the cause was one missing check in the control model.**
+
+`schemaControls` built every numeric slider from two facts off the schema —
+`min` and `max` — and derived its step as `(max - min) / 200`. It never read
+zod's `.int()`. So the moment you touched `seed` on a colonnade, the editor
+wrote `2.5` into a field declared `z.number().int()`.
+
+Nothing warned. `<PaperStageScene>` re-parses its layout options **during
+render** to place the walk's stops, and a parse does not warn about a
+fraction where an integer belongs — it throws:
+
+```
+ZodError: Expected integer, received float — path: ["seed"]
+  at PaperStage.tsx:368  (the `stops` memo)
+```
+
+A throw in render with nothing above it to catch unmounts the tree, which is
+why the app appeared to close rather than to complain.
+
+**Ten fields carried `.int()`** and every one of them was a loaded gun:
+`seed` on pile, spill, accordion and colonnade, `seed` on crumple (behavior
+and deformer), `rows` and `columns` on the sheet grid, `columns` on the rack,
+`segments` on the sheet.
+
+Fixed in the control model, so all ten are covered by one rule: an int field
+gets `step: 1` **and** its emitted value is rounded. Both halves are load-
+bearing — the step is what the slider snaps to, and the rounding is what
+protects the readout you can type into, which clamps but never snaps.
+
+**Then the same question was asked of the rest of the app: where else?**
+Three answers, all now closed:
+
+1. **`StatesBar` had written the schema walk a second time** — its own
+   `min`/`max`/`step` extraction for the per-slot override sliders, missing
+   `.int()` exactly like the first one. Live, and reproduced: a slot on
+   `crumpled-note`, a state chip, drag `seed`, and
+   `resolveFieldSlotConfig` re-parses the slot overrides during render into
+   the same uncaught ZodError. Fixed by deleting the copy — both panels now
+   read `numberSpec`, which is the only thing in the editor that reads a
+   `z.ZodNumber`.
+2. **Exclusive bounds.** `.positive()` is stored as `min: 0, inclusive:
+   false` — the same shape as `.min(0)`, one boolean apart — and the reader
+   took the value and dropped the boolean. That gives a slider whose far end
+   is the one number the schema rejects. Latent rather than live (the two
+   fields carrying it, `sheet.width` and `sheet.height`, are hand-built with
+   a floor of 0.2), and now handled anyway: an excluded endpoint is moved in
+   by a step.
+3. **Hand-written control ranges drifting from their schemas** — the other
+   way this bug could appear, since nineteen controls in the editor state
+   their own min/max instead of reading one. Audited all nineteen against
+   the schema behind them: every range sits inside its schema's. Clean, and
+   worth re-checking whenever a schema bound moves.
+4. **The same shape on the free-text side, and live.** Typing anything that
+   is not a colour into a stage's `zenith` crashed the editor —
+   `addColorStop` is one of the few canvas calls that **throws** rather than
+   ignoring what it cannot parse, and the sky is built during render. Every
+   colour in a stage is a text field, and a text field emits per keystroke,
+   so the library is handed `#f` and `#ff` in the normal course of somebody
+   typing `#ffaa22`. Three.js is the forgiving one — `new THREE.Color(…)`
+   only warns — which is why the gradient was the only path that broke.
+   `cssColorOr` now asks a canvas whether a string is a colour (the canvas's
+   own opinion, not a regex — CSS colours are a bigger set than a regex
+   should be trusted with) and falls back when it is not.
+
+   Worth being explicit about why the fix is not "validate it in the
+   schema": the text control emits on every keystroke, so a `.refine()`
+   would reject `#f` and move the throw rather than remove it. **A value a
+   person is halfway through typing is expected input**, and robustness
+   belongs where it is consumed.
+
+Two things found alongside it, both kept:
+
+- **The editor had no error boundary at all.** Any render throw left a blank
+  page with no message, and reloading walked straight back in whenever the
+  cause was something the session restored. `CrashScreen` now shows the
+  error, the component stack, a copy button, and a *forget the session and
+  reload* escape. This is what turned an unreproducible report into a
+  one-line diagnosis.
+- **`App.resolvePresetByName` called `getPreset`, which throws** on an
+  unregistered name, once per slot per render — so a single stale slot name
+  took down the whole editor rather than one sheet. It now falls back to
+  `photo-print`.
+
+The rule worth keeping: **a schema is a contract in both directions.** Any UI
+generated from one has to emit what that schema accepts, because the code
+receiving it is entitled to parse strictly — and a strict parse inside a
+render is an app-level crash, not a validation message.
+
+---
+
+## Observed once, not reproduced — a renderer crash under synthetic churn
+
+**Seen 2026-08-22 by the audit harness, not by a person. Recorded so it is
+not re-derived from scratch if it ever shows up for real.**
+
+At the tail of a ten-minute scripted run — every slider in every mode, every
+behavior and every layout, driven continuously in one page without a reload —
+the browser tab died outright (Playwright `Target crashed`, which is a
+renderer-process death, not the crash screen). It happened once, at
+`field/spill`.
+
+Three hypotheses, all tested and all **ruled out**:
+
+- **Layout churn leaking.** 72 consecutive scene rebuilds: heap and listener
+  counts rise and fall back (34 → 97 → 62 MB; listeners 273 → 1861 → 561).
+  Sawtooth, not a ratchet.
+- **WebGL contexts leaking on mode switch.** The obvious suspect, since
+  `<Canvas key={mode}>` builds a fresh context every time and the console
+  does print `THREE.WebGLRenderer: Context Lost`. 30 switches: exactly one
+  such line per switch — r3f's expected teardown on unmount — canvas count
+  steady at 4, heap flat at 34–45 MB.
+- **The failing segment itself.** Every field layout × every slider, twice
+  over, 154 drags in one page: survived, heap bounded and returning to
+  ~54 MB between layouts.
+
+So: not reproduced in isolation, and the current read is accumulated pressure
+in a headless browser under a marathon no person would perform, rather than a
+defect a user can reach. Two things worth carrying forward if it recurs:
+`sheet` is by a distance the heaviest layout (223 MB peak against ~70 MB for
+the rest), and the harness that found it lives in the session notes — the
+reproduction is "drive everything for ten minutes without reloading".
+
+---
+
+## Callback props as effect dependencies — one fixed, two left
+
+**Found 2026-08-22, chasing "the whole app freezes when I interact with
+anything." The freeze is fixed; the pattern behind it is not gone.**
+
+`<PaperStageScene>` reported its settled quality tier from an effect that
+named the callback in its dependency list:
+
+```tsx
+useEffect(() => { onQualityChange?.(tier) }, [tier, onQualityChange])
+```
+
+The natural way to pass that prop is an inline arrow, which is a new function
+on every render of the page above — so the effect fired on every consumer
+render, not on every tier change. In the editor the consumer stores the tier,
+which re-renders, which makes another arrow, which fires the effect again.
+A notification had become a pump: **~6 App renders a second at rest in stage
+mode**, each one a full `stageSchema.parse` and walk resample, which is why
+every interaction felt frozen and why dragging the scrubber could take the
+tab out with an out-of-memory crash.
+
+Fixed by holding the callback in a ref and depending on `tier` alone, plus a
+store-side guard so `patchStage` returns the *same* object for a patch that
+changes nothing (`apps/editor/src/store.test.ts` covers the guard).
+
+**What is left.** Two places still have the shape, neither of them a loop
+today, both worth closing:
+
+- `field/dropZones.tsx` — the registration effect names `onPlace`, so a
+  consumer passing an inline handler re-registers the zone on every render.
+  It bumps the registry version and re-renders every `DropZoneVisual`. Churn
+  rather than a loop, because the effect's own component is not what the
+  version change re-renders — which is luck, not design.
+- `stage/PaperStage.tsx` — `stage` arrives as a fresh object literal from the
+  editor, so `stageSchema.parse` and `getWalkPath` both re-run on every
+  render. Harmless per render, and it was the reason each pump iteration cost
+  as much as it did. Serialized deps, the way `PaperFieldMesh` already does
+  it, would settle it.
+
+The general rule this earned: **a callback prop is a notification, not a
+dependency.** If an effect exists to tell the consumer something, it should
+depend on the thing being told, and reach the callback through a ref.
+
+---
+
 ## Next — the ideas we want to build
 
 Ordered by how much each one serves the goal, not by effort.

--- a/packages/paperlab/src/Paper.tsx
+++ b/packages/paperlab/src/Paper.tsx
@@ -1,12 +1,6 @@
 import { Canvas } from '@react-three/fiber'
 import { forwardRef, useMemo } from 'react'
-import {
-  PaperMesh,
-  resolveConfig,
-  resolveConfigKey,
-  type PaperHandle,
-  type PaperMeshProps,
-} from './PaperMesh'
+import { PaperMesh, useResolvedConfig, type PaperHandle, type PaperMeshProps } from './PaperMesh'
 import { PaperFallback, PaperMirror, supportsWebGL } from './a11y'
 import { PaperLighting } from './scene/PaperLighting'
 
@@ -32,8 +26,7 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
 ) {
   // Keyed on every prop resolveConfig reads — a content/stock/behavior change
   // must refresh the fallback, mirror, and lighting, not just the mesh.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: resolveConfigKey serializes every prop resolveConfig reads — the props object itself is new each render.
-  const config = useMemo(() => resolveConfig(meshProps), [resolveConfigKey(meshProps)])
+  const config = useResolvedConfig(meshProps)
   const webgl = useMemo(() => (typeof window === 'undefined' ? true : supportsWebGL()), [])
 
   return (

--- a/packages/paperlab/src/PaperField.tsx
+++ b/packages/paperlab/src/PaperField.tsx
@@ -17,6 +17,7 @@ import { BackingSheet } from './field/backingSheet'
 import { InteractiveField, type FieldA11yController } from './field/interactiveField'
 import { FieldKeyboardMirror } from './field/keyboardMirror'
 import { DEFAULT_SHEET, getLayout } from './field/layouts'
+import { useStable } from './core/stable'
 import type { SheetLayoutOptions } from './field/sheetGrid'
 import { fitCamera, resolveLayoutOptions } from './field/framing'
 
@@ -110,22 +111,27 @@ export const PaperFieldMesh = forwardRef<THREE.Group, PaperFieldMeshProps>(
       () => effectiveFieldPapers(props.papers, props.images),
       [props.papers, props.images],
     )
-    // biome-ignore lint/correctness/useExhaustiveDependencies: Serialized deps — papers and preset are fresh objects every render.
+    // Content-compared, not serialized: papers and preset are fresh objects
+    // every render, and a paper can carry a whole bitmap inline. See
+    // `useStable` for why stringifying these was the expensive half.
+    const stablePapers = useStable(papers)
+    const stablePreset = useStable(props.preset ?? null)
     const groups = useMemo(
-      () => groupFieldPapers(papers, props.preset),
-      [JSON.stringify(papers), JSON.stringify(props.preset ?? null)],
+      () => groupFieldPapers(stablePapers, stablePreset ?? undefined),
+      [stablePapers, stablePreset],
     )
     const total = papers.length
 
     const layoutId = props.layout ?? 'ring'
     const layout = getLayout(layoutId)
     const firstSheet = groups[0]?.config.sheet
-    // biome-ignore lint/correctness/useExhaustiveDependencies: Serialized deps — layoutOptions and the first sheet are fresh objects every render.
+    const stableLayoutOptions = useStable(props.layoutOptions ?? {})
+    // biome-ignore lint/correctness/useExhaustiveDependencies: `layout` is derived from layoutId, and the sheet enters by its two dimensions.
     const layoutOptions = useMemo(
       // Sheet grids size their cells from the papers themselves — gutter is
       // then literally the spacing between stamps (explicit cell dims win).
-      () => resolveLayoutOptions(layoutId, layout, props.layoutOptions, firstSheet),
-      [layoutId, JSON.stringify(props.layoutOptions ?? {}), firstSheet?.width, firstSheet?.height],
+      () => resolveLayoutOptions(layoutId, layout, stableLayoutOptions, firstSheet),
+      [layoutId, stableLayoutOptions, firstSheet?.width, firstSheet?.height],
     )
 
     // ── Shared motion state: one driver phase / entrance clock / morph for
@@ -258,21 +264,20 @@ function FitCamera(meshProps: PaperFieldMeshProps) {
   const width = useThree((s) => s.size.width)
   const height = useThree((s) => s.size.height)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Serialized deps — the camera refits on prop *content*, not on identity.
+  // The camera refits on prop CONTENT, not on identity — compared rather
+  // than serialized, because this runs on every render of the field.
+  const papersProp = useStable(meshProps.papers ?? null)
+  const imagesProp = useStable(meshProps.images ?? null)
+  const presetProp = useStable(meshProps.preset ?? null)
+  const optionsProp = useStable(meshProps.layoutOptions ?? {})
   const field = useMemo(() => {
-    const papers = effectiveFieldPapers(meshProps.papers, meshProps.images)
+    const papers = effectiveFieldPapers(papersProp ?? undefined, imagesProp ?? undefined)
     const layoutId = meshProps.layout ?? 'ring'
     const layout = getLayout(layoutId)
-    const sheet = groupFieldPapers(papers, meshProps.preset)[0]?.config.sheet
-    const options = resolveLayoutOptions(layoutId, layout, meshProps.layoutOptions, sheet)
+    const sheet = groupFieldPapers(papers, presetProp ?? undefined)[0]?.config.sheet
+    const options = resolveLayoutOptions(layoutId, layout, optionsProp, sheet)
     return { layout, n: papers.length, options, sheet: sheet ?? DEFAULT_SHEET }
-  }, [
-    JSON.stringify(meshProps.papers ?? null),
-    JSON.stringify(meshProps.images ?? null),
-    JSON.stringify(meshProps.preset ?? null),
-    meshProps.layout,
-    JSON.stringify(meshProps.layoutOptions ?? {}),
-  ])
+  }, [papersProp, imagesProp, presetProp, meshProps.layout, optionsProp])
 
   useEffect(() => {
     if (!(camera instanceof THREE.PerspectiveCamera)) return
@@ -307,10 +312,11 @@ export const PaperField = forwardRef<THREE.Group, PaperFieldProps>(function Pape
     () => effectiveFieldPapers(meshProps.papers, meshProps.images),
     [meshProps.papers, meshProps.images],
   )
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Serialized deps — must match the mesh derivation above exactly.
+  const stablePapers = useStable(papers)
+  const stablePreset = useStable(meshProps.preset ?? null)
   const interactive = useMemo(
-    () => fieldIsInteractive(papers, meshProps.preset, meshProps.interactive),
-    [JSON.stringify(papers), JSON.stringify(meshProps.preset ?? null), meshProps.interactive],
+    () => fieldIsInteractive(stablePapers, stablePreset ?? undefined, meshProps.interactive),
+    [stablePapers, stablePreset, meshProps.interactive],
   )
 
   return (

--- a/packages/paperlab/src/PaperMesh.tsx
+++ b/packages/paperlab/src/PaperMesh.tsx
@@ -19,6 +19,7 @@ import type {
 import { paperConfigSchema } from './config/schema'
 import { mergeConfig, parsePreset, serializePreset } from './config/serialize'
 import { computeSheetNormals } from './core/normals'
+import { useStable } from './core/stable'
 import { createSheetGeometry, resolveSegments } from './core/sheet'
 import { FLAT_SEGMENTS, type SegmentPair } from './core/tessellation'
 import { getStock } from './core/stock'
@@ -109,11 +110,17 @@ export interface PaperHandle {
 }
 
 /**
- * Stable memo key over every prop {@link resolveConfig} reads. Consumers that
- * cache a resolved config must key on this, not on `preset` alone.
+ * Everything {@link resolveConfig} reads, as a plain tuple.
+ *
+ * Compared with {@link useStable} rather than serialized: a dependency array
+ * is evaluated on EVERY render, and `content` can hold a whole bitmap as a
+ * data URL, so a `JSON.stringify` here was megabytes of garbage per frame of
+ * a slider drag. (There was a `resolveConfigKey` exporting the string form
+ * for consumers to key their own caches on; it was never part of the package
+ * entry, so no consumer could reach it, and nothing else uses it now.)
  */
-export function resolveConfigKey(props: PaperMeshProps): string {
-  return JSON.stringify([
+function configInputs(props: PaperMeshProps): unknown[] {
+  return [
     props.preset ?? null,
     props.sheet ?? null,
     props.stock ?? null,
@@ -124,7 +131,14 @@ export function resolveConfigKey(props: PaperMeshProps): string {
     props.scene ?? null,
     props.physics ?? null,
     props.onTwos ?? null,
-  ])
+  ]
+}
+
+/** Resolve once, and again only when the inputs actually differ. */
+export function useResolvedConfig(props: PaperMeshProps): PaperConfig {
+  const inputs = useStable(configInputs(props))
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `inputs` IS every prop resolveConfig reads; the props object itself is new each render.
+  return useMemo(() => resolveConfig(props), [inputs])
 }
 
 /** Resolve preset + prop overrides into a validated config. */
@@ -171,8 +185,7 @@ const quatScratch = new THREE.Quaternion()
 export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperMesh(props, ref) {
   // Each resolveConfig call is several zod parses (superRefine re-parses every
   // state override) — memoized so a render without config-prop changes is free.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: resolveConfigKey serializes every prop resolveConfig reads — the props object itself is new each render.
-  const resolved = useMemo(() => resolveConfig(props), [resolveConfigKey(props)])
+  const resolved = useResolvedConfig(props)
   // Reduced motion: behaviors freeze at their resting pose, physics is off,
   // idle motion is off. The sheet still renders fully sculpted.
   const reduced = usePrefersReducedMotion(props.reducedMotion)

--- a/packages/paperlab/src/content/atlas.ts
+++ b/packages/paperlab/src/content/atlas.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 import { useEffect, useState } from 'react'
 import type { ContentConfig, SheetConfig } from '../config/schema'
 import type { Stock } from '../core/stock'
+import { useStable } from '../core/stable'
 import { renderContentToCanvas } from './texture'
 
 /**
@@ -38,9 +39,13 @@ export function useContentAtlas(
   stock: Stock,
 ): ContentAtlas | null {
   const [atlas, setAtlas] = useState<ContentAtlas | null>(null)
-  const key = JSON.stringify({ contents, w: sheet.width, h: sheet.height, stock: stock.id })
+  // Compared rather than serialized. An image tile carries its bitmap inline
+  // as a data URL, and this runs on every render of the field — building a
+  // cache key out of the very thing that makes the cache worth having was
+  // costing more per render than the atlas it was protecting.
+  const stableContents = useStable(contents)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: key serializes the contents, sheet and stock the atlas draws from.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the atlas is drawn from the contents, sheet and stock named below.
   useEffect(() => {
     let disposed = false
     const aspect = sheet.height / sheet.width
@@ -92,7 +97,7 @@ export function useContentAtlas(
       disposed = true
       texture.dispose()
     }
-  }, [key])
+  }, [stableContents, sheet.width, sheet.height, stock.id])
 
   return atlas
 }

--- a/packages/paperlab/src/core/stable.test.ts
+++ b/packages/paperlab/src/core/stable.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { deepEqual } from './stable'
+
+/**
+ * `deepEqual` replaced a `JSON.stringify` comparison in the field's memo
+ * deps, so the bar is not "is it a reasonable deep-equal" — it is **does it
+ * draw the same line stringify drew**. Anything it calls equal that
+ * stringify called different would stop the field rebuilding when it should;
+ * anything the other way rebuilds it constantly, which is the cost this was
+ * meant to remove.
+ */
+describe('deepEqual', () => {
+  it('agrees with JSON.stringify across config-shaped values', () => {
+    const cases: [unknown, unknown][] = [
+      [{ a: 1 }, { a: 1 }],
+      [{ a: 1 }, { a: 2 }],
+      [
+        { a: 1, b: 2 },
+        { b: 2, a: 1 },
+      ],
+      [{ a: [1, 2, 3] }, { a: [1, 2, 3] }],
+      [{ a: [1, 2, 3] }, { a: [1, 2] }],
+      [{ a: [1, 2] }, { a: [2, 1] }],
+      [{ a: { b: { c: 'x' } } }, { a: { b: { c: 'x' } } }],
+      [{ a: { b: { c: 'x' } } }, { a: { b: { c: 'y' } } }],
+      [null, null],
+      [null, {}],
+      ['x', 'x'],
+      ['x', 'y'],
+      [1, '1'],
+      [true, false],
+      [[], {}],
+      [{ src: 'data:image/png;base64,AAAA' }, { src: 'data:image/png;base64,AAAA' }],
+      [{ src: 'data:image/png;base64,AAAA' }, { src: 'data:image/png;base64,AAAB' }],
+    ]
+    for (const [a, b] of cases) {
+      // Key order is the one place they legitimately differ: stringify is
+      // order-sensitive and a structural compare is not. Sort both sides so
+      // the oracle answers the question actually being asked.
+      const oracle = JSON.stringify(sortKeys(a)) === JSON.stringify(sortKeys(b))
+      expect(deepEqual(a, b), `${JSON.stringify(a)} vs ${JSON.stringify(b)}`).toBe(oracle)
+    }
+  })
+
+  it('ignores key order, which a serialized dep could not', () => {
+    expect(deepEqual({ width: 1, height: 2 }, { height: 2, width: 1 })).toBe(true)
+  })
+
+  it('treats an explicit undefined as an absent key, the way stringify did', () => {
+    expect(deepEqual({ a: 1, b: undefined }, { a: 1 })).toBe(true)
+    expect(deepEqual({ a: 1 }, { a: 1, b: undefined })).toBe(true)
+    expect(deepEqual({ a: 1, b: undefined }, { a: 1, b: null })).toBe(false)
+  })
+
+  it('compares a fresh wrapper around shared inner objects without walking them', () => {
+    // The hot case: the editor rebuilds the slot array every render while the
+    // configs inside it are the very same objects.
+    const config = { content: { type: 'image', src: 'data:image/png;base64,AAAA' } }
+    expect(deepEqual([{ preset: config }], [{ preset: config }])).toBe(true)
+  })
+
+  it('separates arrays from objects with the same indices', () => {
+    expect(deepEqual([1, 2], { 0: 1, 1: 2 })).toBe(false)
+  })
+
+  it('handles nested arrays of objects, which is what a slot list is', () => {
+    const a = [{ preset: 'card', states: { states: { hover: { overrides: { x: 1 } } } } }]
+    const b = [{ preset: 'card', states: { states: { hover: { overrides: { x: 1 } } } } }]
+    const c = [{ preset: 'card', states: { states: { hover: { overrides: { x: 2 } } } } }]
+    expect(deepEqual(a, b)).toBe(true)
+    expect(deepEqual(a, c)).toBe(false)
+  })
+})
+
+/** Recursively sort object keys, so stringify can act as an order-blind oracle. */
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys)
+  if (value === null || typeof value !== 'object') return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = sortKeys((value as Record<string, unknown>)[key])
+  }
+  return out
+}

--- a/packages/paperlab/src/core/stable.ts
+++ b/packages/paperlab/src/core/stable.ts
@@ -1,0 +1,60 @@
+import { useRef } from 'react'
+
+/**
+ * Deep-equality memo deps, without serializing anything.
+ *
+ * Several hooks here need to recompute on the CONTENT of a prop rather than
+ * on its identity, because the props in question — the paper slots, a
+ * preset, a content list — are rebuilt as fresh objects on every render of
+ * whatever is above. The library used to spell that as
+ * `[JSON.stringify(papers)]`, which reads well and is a trap: a dependency
+ * array is evaluated on **every render**, so the serialization is paid every
+ * render whether or not anything changed, and it is paid in garbage rather
+ * than in time.
+ *
+ * That is affordable for a layout's options and ruinous for a paper. An
+ * image slot carries its bitmap inline as a data URL, so a field of fourteen
+ * photographs serialized roughly seventeen megabytes per render — and the
+ * controls that render the most are the continuous ones, which is why
+ * dragging a speed slider was the way to take the tab out with an
+ * out-of-memory crash.
+ *
+ * `useStable` compares instead of serializing. Nothing is allocated, and the
+ * comparison short-circuits on `Object.is` at every level, so the common
+ * case — a fresh wrapper around the same inner objects — costs a handful of
+ * pointer checks no matter how large the data URL underneath is.
+ */
+export function useStable<T>(value: T): T {
+  const held = useRef(value)
+  if (!deepEqual(held.current, value)) held.current = value
+  return held.current
+}
+
+/**
+ * Structural equality over JSON-shaped data, matching what the
+ * `JSON.stringify` comparison it replaces considered equal.
+ *
+ * That last part is the reason for the `undefined` handling below: stringify
+ * drops a key whose value is `undefined`, so `{a: 1, b: undefined}` and
+ * `{a: 1}` used to compare equal and must go on doing so — a config that
+ * spells an absent option either way should not rebuild the field.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) if (!deepEqual(a[i], b[i])) return false
+    return true
+  }
+
+  const left = a as Record<string, unknown>
+  const right = b as Record<string, unknown>
+  // Keys carrying `undefined` do not count, on either side — see above.
+  const keys = new Set<string>()
+  for (const key of Object.keys(left)) if (left[key] !== undefined) keys.add(key)
+  for (const key of Object.keys(right)) if (right[key] !== undefined) keys.add(key)
+  for (const key of keys) if (!deepEqual(left[key], right[key])) return false
+  return true
+}

--- a/packages/paperlab/src/scene/color.test.ts
+++ b/packages/paperlab/src/scene/color.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { cssColorOr } from './color'
+
+/**
+ * These run in node, where there is no canvas to ask — so what is under test
+ * here is the SSR branch and the contract, and the browser behaviour is
+ * covered by the thing that motivated it: typing `not-a-colour` into a
+ * stage's `zenith` used to crash the editor out of `addColorStop`.
+ */
+describe('cssColorOr', () => {
+  it('passes the value through when there is no DOM to ask', () => {
+    // Nothing is painted without a document, so nothing can throw, and
+    // inventing a colour would silently change a server-rendered scene.
+    expect(cssColorOr('#ffaa22', '#000000')).toBe('#ffaa22')
+    expect(cssColorOr('not-a-colour', '#000000')).toBe('not-a-colour')
+  })
+
+  it('never returns undefined or empty for any input', () => {
+    for (const input of ['', '#f', '#ff', 'rebeccapurple', 'rgb(1,2,3)', 'nonsense']) {
+      const out = cssColorOr(input, '#123456')
+      expect(typeof out).toBe('string')
+    }
+  })
+})

--- a/packages/paperlab/src/scene/color.ts
+++ b/packages/paperlab/src/scene/color.ts
@@ -1,0 +1,61 @@
+/**
+ * Colour strings that came from a person, made safe to hand to a canvas.
+ *
+ * Every colour in a stage — zenith, horizon, ground, the source, the room —
+ * is an editable text field, and a text field emits on every keystroke. So
+ * the library is handed `#f`, and `#ff`, and `not-a-colour`, in the normal
+ * course of somebody typing `#ffaa22`. That is expected input, not a bug in
+ * the caller.
+ *
+ * It matters because `addColorStop` is one of the few canvas calls that
+ * **throws** rather than ignoring what it cannot parse:
+ *
+ * ```
+ * Failed to execute 'addColorStop' on 'CanvasGradient':
+ * The value provided ('not-a-colour') could not be parsed as a color.
+ * ```
+ *
+ * and the sky is built during render, so that throw reached React as an
+ * uncaught error and took the whole editor down. Three.js is the forgiving
+ * one here — `new THREE.Color('nonsense')` warns and carries on — which is
+ * why only the gradient path ever broke.
+ *
+ * Validation is the canvas's own opinion rather than a regex, because the
+ * set of things CSS calls a colour is large (`rebeccapurple`, `hsl(...)`,
+ * `color-mix(...)`, whatever ships next) and a regex would reject valid
+ * input the gradient would have accepted.
+ */
+
+/** A 1×1 scratch context, made once, used only to ask "is this a colour?". */
+let probe: CanvasRenderingContext2D | null | undefined
+
+function probeContext(): CanvasRenderingContext2D | null {
+  if (probe !== undefined) return probe
+  probe = typeof document === 'undefined' ? null : document.createElement('canvas').getContext('2d')
+  return probe
+}
+
+/**
+ * `value` if a canvas can parse it as a colour, else `fallback`.
+ *
+ * The test is two assignments from two different starting colours. An
+ * invalid value leaves `fillStyle` untouched, so it still reads back as
+ * whichever prior it started from and the two readings disagree; a valid one
+ * normalizes to the same string both times. One assignment would not do —
+ * the answer would depend on what the context happened to hold.
+ */
+export function cssColorOr(value: string, fallback: string): string {
+  const ctx = probeContext()
+  // No DOM (SSR, tests): pass the value through rather than invent a colour.
+  // Nothing is being painted, so nothing can throw.
+  if (!ctx) return value
+  const previous = ctx.fillStyle
+  ctx.fillStyle = '#000000'
+  ctx.fillStyle = value
+  const fromBlack = ctx.fillStyle
+  ctx.fillStyle = '#ffffff'
+  ctx.fillStyle = value
+  const fromWhite = ctx.fillStyle
+  ctx.fillStyle = previous
+  return fromBlack === fromWhite ? value : fallback
+}

--- a/packages/paperlab/src/scene/environment.ts
+++ b/packages/paperlab/src/scene/environment.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import type { LightingPreset } from './lighting'
 import { lightAngles } from './lighting'
+import { cssColorOr } from './color'
 
 /**
  * The room, drawn as an equirectangular image so it can light things.
@@ -44,7 +45,11 @@ export function skyV(elevationDeg: number): number {
  * region is the wall, not a mathematical line through it.
  */
 export function drawSky(ctx: CanvasRenderingContext2D, preset: LightingPreset): void {
-  const { zenith, horizon, ground } = preset.sky
+  // Guarded: a stage's sky colours are editable text, and `addColorStop`
+  // throws on anything it cannot parse. See `cssColorOr`.
+  const zenith = cssColorOr(preset.sky.zenith, '#241c17')
+  const horizon = cssColorOr(preset.sky.horizon, '#fff4e2')
+  const ground = cssColorOr(preset.sky.ground, '#141210')
   const grade = ctx.createLinearGradient(0, 0, 0, HEIGHT)
   grade.addColorStop(0, zenith)
   grade.addColorStop(0.32, zenith)

--- a/packages/paperlab/src/stage/PaperStage.tsx
+++ b/packages/paperlab/src/stage/PaperStage.tsx
@@ -265,9 +265,25 @@ export function PaperStageScene({
   useEffect(() => {
     if (quality !== 'auto') setTier(quality as QualityTier)
   }, [quality])
+  /**
+   * Report the tier when the TIER moves — never because the consumer
+   * re-rendered.
+   *
+   * Held in a ref rather than named as a dependency, because the natural way
+   * to write this prop is an inline arrow, and an inline arrow is a new
+   * function on every render of the page above. Depending on it turned a
+   * notification into a pump: report → consumer stores the tier → consumer
+   * re-renders → new callback identity → report again, forever. The editor
+   * spent every frame in stage mode servicing that loop, which is what made
+   * the whole app feel frozen the moment you touched anything.
+   */
+  const reportQuality = useRef(onQualityChange)
   useEffect(() => {
-    onQualityChange?.(tier)
-  }, [tier, onQualityChange])
+    reportQuality.current = onQualityChange
+  })
+  useEffect(() => {
+    reportQuality.current?.(tier)
+  }, [tier])
   const settings = quality === 'auto' ? qualityTiers[tier] : qualityFor(quality)
 
   const stage = useMemo(() => stageSchema.parse(stageInput ?? {}), [stageInput])

--- a/packages/paperlab/src/stage/Surround.tsx
+++ b/packages/paperlab/src/stage/Surround.tsx
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import { useEffect, useMemo } from 'react'
+import { cssColorOr } from '../scene/color'
 
 /**
  * The cyclorama: an inverted sphere graded from the source colour at the
@@ -27,14 +28,20 @@ export function makeSkyTexture(sky: SkyColors): THREE.CanvasTexture {
   canvas.height = 256
   const ctx = canvas.getContext('2d')!
   const grade = ctx.createLinearGradient(0, 0, 0, canvas.height)
+  // These three are typed into text fields, so mid-keystroke they are not
+  // colours yet — and `addColorStop` throws on what it cannot parse, from
+  // inside a render. See `cssColorOr`.
+  const zenith = cssColorOr(sky.zenith, '#241c17')
+  const horizon = cssColorOr(sky.horizon, '#fff4e2')
+  const ground = cssColorOr(sky.ground, '#141210')
   // Canvas row 0 is the top of the sphere. The grade has to travel most of
   // the way down: held flat until near the horizon it reads as a dark lid
   // over a bright slot, which is the black void this is here to remove.
-  grade.addColorStop(0, sky.zenith)
-  grade.addColorStop(0.3, sky.zenith)
-  grade.addColorStop(0.62, sky.horizon)
-  grade.addColorStop(0.7, sky.horizon)
-  grade.addColorStop(1, sky.ground)
+  grade.addColorStop(0, zenith)
+  grade.addColorStop(0.3, zenith)
+  grade.addColorStop(0.62, horizon)
+  grade.addColorStop(0.7, horizon)
+  grade.addColorStop(1, ground)
   ctx.fillStyle = grade
   ctx.fillRect(0, 0, canvas.width, canvas.height)
   const texture = new THREE.CanvasTexture(canvas)


### PR DESCRIPTION
Two reports, both real, neither what it sounded like. **"The whole app freezes when I interact with anything"** was a render loop. **"Whenever I try to manage speed the app gets closed"** was a blank white page — and the control it names is `seed`, one letter away.

## The freeze — a notification that had become a pump

`<PaperStageScene>` reported its settled quality tier from an effect that named the callback in its own dependency list. The natural way to write that prop is an inline arrow, which is a new function on every render of the page above — so the effect fired on every **consumer render**, not on every tier change:

> report → consumer stores the tier → consumer re-renders → new callback identity → report again

Measured at **~6 App renders a second at rest** in stage mode (0 after the fix), each one a full `stageSchema.parse` and walk resample. Pausing hung for >30s; dragging the scrubber crashed the tab outright with an out-of-memory error.

The callback now lives in a ref and the effect depends on `tier` alone. **A callback prop is a notification, not a dependency.**

## The crash — `.int()`, and everywhere else the same shape hid

Generated sliders took two facts off a schema — `min` and `max` — and derived a step of `(max - min) / 200`. They never read `.int()`. So touching `seed` on a colonnade wrote `2.5` into a `z.number().int()`, and `PaperStage.tsx:368` re-parses its layout options **during render**:

```
ZodError: Expected integer, received float — path: ["seed"]
```

A strict parse doesn't warn about a fraction; it throws, inside a render, and React unmounts everything. **Ten fields carry `.int()`** — `seed` on four layouts and on crumple, `rows`/`columns` on the sheet grid, `columns` on the rack, `segments` on the sheet.

Asking *where else does this shape hide* found three more:

| | status |
|---|---|
| `StatesBar` had written the schema walk a **second time**, missing `.int()` identically, crashing through a different render-time parse (`resolveFieldSlotConfig`) | **live, reproduced** — fixed by deleting the copy |
| `.positive()` is stored as `min: 0, inclusive: false` — one boolean from `.min(0)` — so dropping the boolean gives a slider whose end is the one number the schema rejects | latent, handled |
| Sky colours are text fields emitting per keystroke, so the library gets `#f` while somebody types `#ffaa22` — and `addColorStop` **throws** rather than ignoring what it can't parse | **live, reproduced** — `cssColorOr` |

Not fixed in the schema deliberately: a `.refine()` would reject `#f` and *move* the throw rather than remove it. A half-typed value is expected input; robustness belongs at the consumer.

**A schema is a contract in both directions.** Anything generated from one must emit what that schema accepts, because the receiving code is entitled to parse strictly — and a strict parse inside a render is an app-level crash, not a validation message.

## The editor had no error boundary

Which is why all of this presented as a blank page with no message, and a reload walked straight back in whenever the cause was persisted. `CrashScreen` shows the error, the component stack, a copy button, and a *forget the session and reload* escape. It earned its place on first use — the `seed` diagnosis took one screenshot instead of another round of guessing.

`App.resolvePresetByName` also called `getPreset`, which **throws** on an unknown name, once per slot per render — one stale slot name took down the whole editor rather than one sheet. It falls back now.

## Dependency arrays are evaluated every render

`PaperFieldMesh`, `FitCamera`, `useContentAtlas` and the resolved-config memo used `JSON.stringify` as memo deps — paid on every render whether or not anything changed, and paid in garbage rather than time. Fourteen image papers re-serialized **~17 MB per render**, since an image slot carries its bitmap inline as a data URL. `useStable` compares instead: allocates nothing, short-circuits on `Object.is` at every level.

## Verification

Driven in a real browser, not reasoned about:

- Every slider in **every mode, every behavior (12), every layout (12)** — end to end, checked for the crash screen after each
- Five kinds of garbage into all **9 stage text fields**
- 19 hand-written control ranges audited against their schemas — all inside
- Ruled out three theories for a renderer crash seen once under synthetic churn: layout churn (72 rebuilds), WebGL context leaking on mode switch (30 switches), and the failing segment itself (154 drags) — all clean; written up in `docs/roadmap.md`

`lint`, `typecheck`, `build`, `knip` clean. **577 tests** — the new ones assert the property that matters: `numberSpec` emits only values the schema accepts, over the eight numeric shapes the library actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)