### PR TITLE
fix(paperlab): the pool, the measure, and a bug that was not one

### DIFF
--- a/.changeset/the-pool-and-the-column.md
+++ b/.changeset/the-pool-and-the-column.md
@@ -1,0 +1,13 @@
+---
+"paperlab": patch
+---
+
+The ribbon stage renders what it is for, and banner type is set to the measure.
+
+**`ribbon`'s crease could not reach a right angle.** `foldAngle` was `62 + curl * 46`, so below curl 0.61 — including the default, and including the value the ribbon stage shipped — the pooled length was still travelling downward when it passed the crease and went through the floor. Above 0.61 it tilted back up and floated. A hinge turns through one angle and the flap holds that heading, so only 90° is the floor: it is fixed at 90 now, and `curl` drives the crease radius, which is what its own description always said it did. The crease is also placed a hinge-radius higher, because the flap leaves the hinge cylinder that much below the crease line — measured at ~9cm under the floor on the stage's own numbers.
+
+**`ribbon` uses `drape` again.** It had been switched to `wave` to work around a report that `drape` rendered an invisible sheet on the CPU path. That report does not reproduce; it rested on counting colours in a screenshot, and a near-flat strip filling the frame has about as many colours as an empty one. `wave` was never the same picture either — a sine runs at one amplitude end to end, and a hung strip is flat where it is held and gathers as it falls.
+
+**Banner type was sized by the drop and never by the measure.** On a tall narrow banner the chosen size was wider than the sheet, so every word was broken wherever the measure ran out and the column then overran the drop and was clipped. `bannerTextSize` now takes the longest word and the measure (`bannerMeasure` states how much room there is, once), and a single-word column is set one letter to a line on purpose (`letterColumn`) instead of being shattered at arbitrary points — `carried` reads down its banner rather than as `ca / rr / ie / d`. Columns are centred down the drop, since one size is shared by the whole rank. `splitAcrossBanners` also dealt with a stride that dropped banners: twenty words over twelve gave ten columns and left two blank.
+
+**New: `deformers/draws.test.ts`** — every registered deformer, built into a real sheet on two aspect ratios, asserted to be finite, actually moved, still to have most of its area, and to have unit normals. A parity gate proves the two implementations agree, not that either one draws; this is the missing half, and a new deformer cannot skip it.

--- a/apps/editor/src/store.test.ts
+++ b/apps/editor/src/store.test.ts
@@ -44,3 +44,60 @@ describe('patchStage', () => {
     expect(useEditor.getState().stage.playing).toBe(!before.playing)
   })
 })
+
+/**
+ * `inspectorEpoch` remounts the whole inspector, which resets every folder's
+ * open/closed state. That is right when the SUBJECT changes — a new preset,
+ * a new behavior, a new mode — and wrong when only a value does.
+ *
+ * It was wrong in four places, and the drop-zone one was visible: opening
+ * "Drop zones" and pressing "Add a drop zone" closed the folder on the zone
+ * you had just made. The state-override resets had the same shape — you open
+ * a folder to find the control you want to reset, and resetting it closes
+ * the folder. Each of these setters changes values the inspector already
+ * derives from the store on every render, so none of them needs a remount.
+ */
+describe('the inspector is not remounted for a value change', () => {
+  const epoch = () => useEditor.getState().inspectorEpoch
+
+  it('adding and removing a drop zone', () => {
+    const before = epoch()
+    useEditor.getState().addZone()
+    expect(useEditor.getState().field.zones.length).toBeGreaterThan(0)
+    useEditor.getState().removeZone(useEditor.getState().field.zones.length - 1)
+    expect(epoch()).toBe(before)
+  })
+
+  it('clearing one recorded state override', () => {
+    useEditor.getState().setEditingState('hover')
+    useEditor.getState().patchConfig({ surface: { grain: 0.7 } })
+    useEditor.getState().setEditingState(null)
+    const before = epoch()
+    useEditor.getState().clearStateOverride('hover', 'surface.grain')
+    expect(epoch()).toBe(before)
+  })
+
+  it('resetting a whole state to base', () => {
+    useEditor.getState().setEditingState('pressed')
+    useEditor.getState().patchConfig({ surface: { grain: 0.6 } })
+    useEditor.getState().setEditingState(null)
+    const before = epoch()
+    useEditor.getState().resetStateOverrides('pressed')
+    expect(useEditor.getState().config.states?.states.pressed?.overrides).toEqual({})
+    expect(epoch()).toBe(before)
+  })
+
+  it('clearing a slot-layer override', () => {
+    useEditor.getState().patchSlotState(0, 'hover', { behavior: { progress: 0.6 } })
+    const before = epoch()
+    useEditor.getState().clearSlotState(0, 'hover')
+    expect(epoch()).toBe(before)
+  })
+
+  it('but still remounts when the subject changes', () => {
+    const before = epoch()
+    useEditor.getState().setMode('field')
+    expect(epoch()).toBeGreaterThan(before)
+    useEditor.getState().setMode('paper')
+  })
+})

--- a/apps/editor/src/store.ts
+++ b/apps/editor/src/store.ts
@@ -304,6 +304,10 @@ export const useEditor = create<EditorState>((set, get) => ({
         node = node[keys[i]!] as Record<string, unknown> | undefined
       }
       if (node) delete node[keys[keys.length - 1]!]
+      // No epoch bump — see `addZone`. Clearing an override changes VALUES
+      // the inspector already reads from the store on every render; it does
+      // not change the subject. Remounting for it would close every folder
+      // the person had opened to find the control they are resetting.
       return {
         config: paperConfigSchema.parse({
           ...s.config,
@@ -312,7 +316,6 @@ export const useEditor = create<EditorState>((set, get) => ({
             states: { ...s.config.states!.states, [name]: { ...def, overrides } },
           },
         }),
-        inspectorEpoch: s.inspectorEpoch + 1,
       }
     }),
   resetStateOverrides: (name) =>
@@ -327,7 +330,6 @@ export const useEditor = create<EditorState>((set, get) => ({
             states: { ...s.config.states!.states, [name]: { ...def, overrides: {} } },
           },
         }),
-        inspectorEpoch: s.inspectorEpoch + 1,
       }
     }),
   setSelectedSlot: (i) => set({ selectedSlot: i }),
@@ -356,10 +358,7 @@ export const useEditor = create<EditorState>((set, get) => ({
       const slotStates = { ...s.field.slotStates }
       if (Object.keys(states).length === 0 && !existing.initial) delete slotStates[slot]
       else slotStates[slot] = { ...existing, states }
-      return {
-        field: { ...s.field, slotStates },
-        inspectorEpoch: s.inspectorEpoch + 1,
-      }
+      return { field: { ...s.field, slotStates } }
     }),
   addZone: () =>
     set((s) => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,6 +117,60 @@ twin; `pnpm test:parity` is a hard gate, not a suggestion.
 
 ---
 
+## The build order
+
+A product review on 2026-08-21 produced a sequenced plan, and **the plan
+lived only in an artifact link until now** — which was itself one of its own
+Phase 00 tasks, left open through five phases. It is here so that it can be
+checked against the repo, which is how the gaps below were found.
+
+**The sequencing principle, which is the part worth keeping:** phases are
+ordered by *what has to be true before the next thing can be built without
+being built twice*, not by importance. The grade goes first because every
+later frame is judged through it. The paper-content renderer goes before any
+gallery stage because all four stages are typographic. The room and the
+shared primitives go before the stages that inherit them. Only one stage is
+above the launch gate; the rest ship after, on purpose, as the content
+cadence.
+
+| # | phase | done test | status |
+|---|---|---|---|
+| 00 | Ground | a stranger can open all three apps; the README promises nothing missing | **partly** — repo public, Pages live, plan now landed here. **README honesty pass still owed** (deferred to phase 07 on purpose) |
+| 01 | The grade | the source reads as light; white paper keeps its hue | done |
+| 02 | The material | open Field mode, change nothing, screenshot: it is a portfolio image | done |
+| 03 | The room | a frame with nobody in it reads as a large room | **partly** — see below |
+| 04 | The primitives | a hung sheet shows what suspends it; a fallen sheet lies convincingly | **partly** — see below |
+| 05 | Ribbon | a still stops someone scrolling with no caption | done, after the four defects above were fixed |
+| 06 | The tool, structurally | a stranger changes the one thing they meant to, and undoes it | done |
+| 07 | Honesty | every URL on a phone, cold cache, nothing confusing or blank | **not started** |
+| — | launch gate | publish 0.3.0, render assets, Product Hunt | blocked on 07 |
+| 08 | The rest of the gallery | one stage every couple of weeks | after launch, deliberately |
+
+### What phases 03 and 04 did not build
+
+Recorded rather than quietly dropped. Neither is a defect — both stages'
+done tests pass — but both are less than the plan asked for, and nothing had
+written down which parts were skipped or why.
+
+**Phase 03 asked for five pieces of architecture: a ceiling, a column with a
+base plate, a doorway, floor slab seams, and a wall corner.** Two shipped —
+`stage.room` (the ceiling) and `ground.slab` (the seams). The column, the
+doorway and the wall corner were never built. The argument for them is the
+one that retired the walking figure in the first place: *architecture is a
+better scale cue than a human mesh, and it is the thing renderers never fail
+at.* A column with a base plate is the strongest of the five, because a base
+plate is a knowable size at a knowable height and it stands IN the scene
+rather than bounding it. Worth building before the launch assets are shot.
+
+**Phase 04 asked for "thread, clips, pegs, a rod".** Thread and clips
+shipped; pegs and a rod did not. This one is defensible as it stands — one
+suspension that works everywhere beats four that half do — but the rod in
+particular is what the canopy and suspension stages (phase 08) will want,
+because a rank of sheets hung from a common rod is a different image from a
+rank each on its own thread.
+
+---
+
 ## Now — the launch runway
 
 This was filed as pure distribution, no code. One of the two turned out to
@@ -292,44 +346,111 @@ this; these two had simply never been held to it.
 
 ---
 
-## Open bug — `drape` renders nothing on the hero path
+## The `drape` bug that was not one — *closed 2026-08-23*
 
-**Found 2026-08-22 while building the `ribbon` behavior. Not yet fixed.**
+**The open bug filed here on 2026-08-22 does not reproduce, and the way it
+was wrong is worth more than the bug would have been.**
 
-The `drape` deformer produces an **invisible sheet** when it runs through the
-hero (CPU/JS) path. Not a faint one — the frame contains exactly one colour,
-the background.
+It said `drape` rendered an invisible sheet on the hero path, on the evidence
+that a screenshot of it contained **exactly one colour** while the same frame
+of `roll` contained 698. Re-run against every case it named — the reported
+0.85 x 6.4 sheet, the ribbon stage's 1.05 x 9 banner, an explicit
+`segments: 96`, a square sheet, and the option range at its extremes —
+`drape` draws every time.
 
-What was ruled out, in order:
+**Counting colours cannot tell an empty frame from one flat surface filling
+it.** A tall drape at that scale is a nearly flat, nearly evenly lit white
+plane edge to edge; a roll is a cylinder, so of course it has hundreds of
+shades. The measurement answered a different question from the one being
+asked, and the answer was read as if it had not.
 
-- **The math.** `drape.displace` was swept across its whole option range on a
-  0.85 x 6.4 sheet: every vertex finite, every value bounded. The node probe
-  is clean.
-- **Tessellation.** The stack resolves to a `[72, 8]` grid, because `drape`
-  declares `axis: 0` (its folds run across the WIDTH) and so asks for zero
-  segments down the length, where the stack floor for that axis is 2. That
-  looked like the answer and is not: pinning the sheet to an explicit
-  `segments: 96` renders the same single colour.
-- **The sheet and the content.** The identical sheet and text render fine
-  with `hang` (bend + wave) at the same camera.
+What the report got right is the gap it named — *"a parity gate proves the
+two implementations agree, not that either one draws"* — and that gap was
+real. Both halves of `drape` could have returned zero forever and every test
+in the repo would still have passed: `drape.test.ts` checks `displace` at
+chosen uvs, parity checks CPU against GPU, and nothing checked that the
+pipeline between them produces a surface.
 
-Isolated by bisecting the ribbon stack one deformer at a time: `roll` alone
-renders (698 colours), `drape` alone is blank, both together blank.
+`deformers/draws.test.ts` closes it. For every registered deformer, on an
+ordinary sheet and on a tall banner, it builds the real geometry the way
+`<PaperMesh>` does and asserts the sheet is finite, actually moved, still has
+most of its area, and has unit normals to light. Verified to fail by
+collapsing `drape` on purpose. **A new deformer cannot skip it** — the last
+case asserts the table covers the registry.
 
-**Why nobody had hit it.** `drape` had exactly one caller in the entire
-library — the stage banner in `stage/PaperStage.tsx` — and that goes through
-the field/GPU path, which uses the GLSL twin. No behavior and no paper preset
-had ever put `drape` on the CPU side. `ribbon` was the first, which is how a
-deformer that ships with a parity gate can still be half-broken: **parity
-proves the two implementations agree, not that either one draws.**
+---
 
-`ribbon` therefore uses `wave` pinned at the top, which is the same picture
-by another road and is proven on both paths. That is a workaround, not a fix.
+## Phase 05 — the ribbon stage did not render what it is for — *fixed 2026-08-23*
 
-Worth checking when this is picked up: whether the normals come out
-degenerate (`computeSheetNormals` over a grid that drape has pinched in x via
-`gather`), and whether any other deformer has the same never-exercised-on-CPU
-status.
+The stage shipped and was never looked at closely enough. Four separate
+defects, three of them in the same eight lines.
+
+**The crease could not reach a right angle.** `foldAngle` was `62 + curl*46`
+— 62° to 108°. A hinge turns through one angle and the pooled length holds
+that heading from the crease onward, so **only a right angle is the floor**:
+under it the pool keeps descending and goes through the ground, over it the
+pool tilts back up and floats above it. The default (0.45) and the stage
+preset's own value (0.34) were both under. The pool — the entire subject of
+the stage — was inside the floor, and the frame showed flat strips stopping
+dead at the ground. `foldAngle` is now exactly 90 and `curl` drives the
+crease RADIUS, which is what its own description always claimed it did.
+
+**And the crease was placed as if the hinge had no size.** It wraps a
+cylinder of `radius / φ`, so the flap leaves it that much lower than the
+crease line — measured at about 9cm below the floor on the stage's own
+numbers. The crease now goes up by the hinge's own radius, because what has
+to land on the floor is the pool; where the crease sits follows from that.
+
+**It used `wave` where it meant `drape`**, working around the bug above that
+does not exist. `wave` was never the same picture: a sine runs at one
+amplitude end to end, and a hung strip is flat where it is held and gathers
+as it falls — which is `falloff`, and it narrows as it gathers, which is
+`gather`. Neither exists in `wave`.
+
+**The type was a two-word label at the top of nine metres of blank paper.**
+See below; the same bug had the whole stage set wrong.
+
+---
+
+## Banner typesetting was sized by the drop and never by the measure — *fixed 2026-08-23*
+
+`bannerTextSize` chose a size to fill the DROP and never asked how wide the
+banner was. On the ribbon stage's 1.05 x 9 strip — about 105px of measure
+once the margins are off — a two-word column asked for 150px type, every word
+came out wider than the sheet, `wrapLines` broke each one wherever the
+measure ran out, and the column then overran the drop and was silently
+clipped. The frame showed one enormous letter per strip.
+
+Fixing the cap exposed the bigger thing underneath. **Every built-in stage
+has fewer words than banners** — a nave of eighteen carries fifteen — so
+nearly every column is a single word. The old code "filled" the drop by
+shattering that word at arbitrary points: `carried` set as `ca / rr / ie / d`,
+which is vertical and full-length and unreadable as a word, because the
+break points were an accident of arithmetic rather than a decision.
+
+Three changes, and the stages read as designed for the first time:
+
+- **`letterColumn`** sets a single word one letter to a line, on purpose.
+  It is a whole-rank decision (`words <= banners`), not a per-banner one —
+  mixing letters and words at one shared size would always be wrong for one
+  of them. `carried` now reads down its banner.
+- **The measure caps the size**, so no word is ever broken by accident.
+- **`valign: 'center'`.** One size is shared by the rank, so a short word
+  necessarily leaves slack, and the slack belongs at both ends rather than
+  all at the bottom.
+
+**`splitAcrossBanners` also dropped banners.** It sliced at a fixed
+`ceil(words / banners)` stride, so twenty words across twelve banners gave
+TEN columns and two banners hung blank. It deals the words out now, odd ones
+at the front.
+
+**The ribbon stage got a passage instead of a caption.** The arithmetic is
+worth keeping: a 1.05-wide strip holds ~105px of measure, which caps the type
+near 26px, which means a column needs roughly twenty-six words to reach the
+bottom of a nine-metre drop. Twelve strips wanted three hundred words; the
+stage now runs eight strips and two hundred, with every word kept to seven
+letters or fewer — because the measure is narrow and **one long word shrinks
+the type on every banner in the room**.
 
 ---
 

--- a/packages/paperlab/src/behaviors/behaviors.test.ts
+++ b/packages/paperlab/src/behaviors/behaviors.test.ts
@@ -1,3 +1,4 @@
+import * as THREE from 'three'
 import { describe, expect, it } from 'vitest'
 import { peel } from './peel'
 import { unroll } from './unroll'
@@ -7,7 +8,8 @@ import { flight } from './flight'
 import { getBehavior, listBehaviors } from './registry'
 import { behaviorConfigSchema, paperConfigSchema } from '../config/schema'
 import { settle } from './settle'
-import { ribbon } from './ribbon'
+import { ribbon, ribbonOptionsSchema } from './ribbon'
+import { getDeformer } from '../deformers/registry'
 
 const sheet = { width: 1, height: 2.6 }
 
@@ -216,17 +218,31 @@ describe('ribbon — the strip that reaches the floor and keeps going', () => {
       angle: number
     }
 
-  it('creases at the floor line, which it can only know from the sheet', () => {
+  /**
+   * The crease sits a hinge-radius ABOVE the floor line, on purpose.
+   *
+   * These two used to assert the crease landed exactly on it, which is the
+   * arithmetic that put the pool underneath the ground — the hinge wraps a
+   * cylinder of `radius / φ` and the flap leaves it that much lower. What
+   * has to land on the line is the pool; where the crease goes follows from
+   * that. See "lands the pool ON the floor" below, which measures the thing
+   * itself rather than the intermediate.
+   */
+  const hingeDrop = (o: Partial<typeof ribbon.defaults>, sheet = { width: 0.9, height: 8 }) =>
+    fold(o, sheet).radius / (Math.PI / 2)
+
+  it('creases a hinge above the floor line, which it can only know from the sheet', () => {
     // Almost every behavior takes only its options. This one cannot: "a
     // pool-length above the bottom edge" is meaningless without a height.
     const sheet = { width: 0.9, height: 8 }
-    // pool 0.25 of an 8-high sheet -> the crease sits 2 above the bottom
-    // edge, i.e. at y = -4 + 2 = -2, measured downward as +2.
-    expect(fold({ pool: 0.25 }, sheet).offset).toBeCloseTo(2)
+    // pool 0.25 of an 8-high sheet -> the floor line is 2 above the bottom
+    // edge, i.e. at y = -4 + 2 = -2, measured downward as +2 — and the
+    // crease goes one hinge higher so the flap comes to rest on it.
+    expect(fold({ pool: 0.25 }, sheet).offset).toBeCloseTo(2 - hingeDrop({ pool: 0.25 }, sheet), 6)
   })
 
   it('a ribbon with no pool creases at its own bottom edge — nothing lies down', () => {
-    expect(fold({ pool: 0 }).offset).toBeCloseTo(4)
+    expect(fold({ pool: 0 }).offset).toBeCloseTo(4 - hingeDrop({ pool: 0 }), 6)
   })
 
   it('the crease travels DOWN the drop, not up it', () => {
@@ -240,12 +256,82 @@ describe('ribbon — the strip that reaches the floor and keeps going', () => {
     expect(long).toBeGreaterThan(short)
   })
 
-  it('curl lays the pool flatter, and never folds it back past double', () => {
-    expect(fold({ curl: 1 }).foldAngle).toBeGreaterThan(fold({ curl: 0 }).foldAngle)
-    for (const curl of [0, 0.5, 1]) {
-      expect(fold({ curl }).foldAngle).toBeLessThanOrEqual(180)
-      expect(fold({ curl }).foldAngle).toBeGreaterThan(0)
+  /**
+   * The one that matters, and the one a bounds check on 0..180 was standing
+   * in for while being satisfied by a broken value.
+   *
+   * A hinge turns through one angle and the pooled length holds that heading
+   * from the crease onward, so only a right angle is the floor. Under it the
+   * pool keeps descending and goes through the ground; over it the pool
+   * tilts back up and floats above it. The range shipped as `62 + curl * 46`
+   * — 62°..108° — so it was wrong in one direction below curl 0.61 and wrong
+   * in the other above, and right only at a single setting nothing used.
+   */
+  it('creases to a right angle at every setting — that is the only angle the floor is', () => {
+    for (const curl of [0, 0.25, 0.45, 0.5, 0.75, 1]) {
+      expect(fold({ curl }).foldAngle, `curl ${curl} does not lay the pool on the floor`).toBe(90)
     }
+  })
+
+  /**
+   * The whole stage, in one number.
+   *
+   * `colonnade` hangs a ribbon so that the crease sits on the floor —
+   * `hover: -pool` — and the behavior has to make the POOL land there, which
+   * is not the same thing. The hinge wraps a cylinder of `radius / φ` and
+   * the flap leaves it that much lower than the crease line, so placing the
+   * crease at the floor put the pooled length about 9cm UNDER it. On the
+   * ribbon stage that meant the paper on the ground, the entire subject, was
+   * inside the ground.
+   *
+   * This walks the strip the way the renderer does and asks where the pooled
+   * end actually is, in the world, with the layout's own hover applied.
+   */
+  it('lands the pool ON the floor, not under it', () => {
+    const sheet = { width: 1.05, height: 9 }
+    for (const curl of [0, 0.34, 0.7, 1]) {
+      const o = ribbonOptionsSchema.parse({ pool: 0.22, curl, drape: 0.6 })
+      const stack = ribbon.stack(o, sheet).map((d) => ({
+        type: d.type,
+        options: getDeformer(d.type).optionsSchema.parse(d.options),
+      }))
+      // Where colonnade puts the sheet's centre for `hover: -pool`.
+      const centreY = sheet.height / 2 + sheet.height * -0.22
+      const out = new THREE.Vector3(0, -sheet.height / 2, 0)
+      const uv = new THREE.Vector2(0.5, 0)
+      for (const d of stack) getDeformer(d.type).displace(out, uv, d.options as never, { t: 0, sheet })
+      const worldY = centreY + out.y
+      expect(worldY, `curl ${curl}: the pooled end is ${worldY} — under the floor`).toBeGreaterThanOrEqual(0)
+      // …and resting on it, not hovering somewhere above it.
+      expect(worldY, `curl ${curl}: the pooled end floats at ${worldY}`).toBeLessThan(0.35)
+      // It has to actually run OUT along the ground to be a pool at all.
+      expect(out.z, `curl ${curl}: nothing lies down`).toBeGreaterThan(sheet.height * o.pool * 0.7)
+    }
+  })
+
+  it('curl tightens the crease instead, which is what it always said it did', () => {
+    expect(fold({ curl: 1 }).radius).toBeLessThan(fold({ curl: 0 }).radius)
+    for (const curl of [0, 0.5, 1]) {
+      expect(fold({ curl }).radius).toBeGreaterThan(0)
+      expect(fold({ curl }).radius).toBeLessThanOrEqual(0.5)
+    }
+  })
+
+  it('folds by the length that is meant to be lying down, not by the whole drop', () => {
+    // The crease sits `pool` of the height above the bottom edge, so raising
+    // pool has to move the hinge UP the sheet, never past its middle.
+    const sheet = { width: 0.9, height: 8 }
+    expect(fold({ pool: 0.5 }, sheet).offset).toBeLessThanOrEqual(0)
+    expect(fold({ pool: 0.1 }, sheet).offset).toBeGreaterThan(fold({ pool: 0.4 }, sheet).offset)
+  })
+
+  it('gathers its folds toward the floor, not evenly down the drop', () => {
+    // `wave` ran at one amplitude end to end; a hung strip is flat where it
+    // is held. That difference is the reason this uses `drape`.
+    const drape = ribbon.stack(ribbon.defaults, { width: 0.9, height: 8 }).find((d) => d.type === 'drape')
+    expect(drape, 'ribbon no longer drapes').toBeDefined()
+    expect((drape!.options as { falloff: number }).falloff).toBeGreaterThan(1)
+    expect((drape!.options as { pinnedEdge: string }).pinnedEdge).toBe('top')
   })
 
   it('hangs still — a ribbon is not a flag', () => {

--- a/packages/paperlab/src/behaviors/ribbon.ts
+++ b/packages/paperlab/src/behaviors/ribbon.ts
@@ -29,9 +29,9 @@ export type RibbonOptions = z.infer<typeof ribbonOptionsSchema>
  * like a caption. It is the payoff for all of them.
  *
  * The mathematics is not new, which is the point of the contribution ladder.
- * A ribbon is a `drape` down its length and a `roll` that begins near the
- * bottom edge instead of at the sheet's centre — `roll.boundary` has always
- * been able to say "start here", and nothing had ever asked it to.
+ * A ribbon is a `drape` down its length and a `fold` whose hinge sits at the
+ * floor line rather than at the sheet's centre — `fold.offset` has always
+ * been able to say "crease here", and nothing had ever asked it to.
  */
 export const ribbon: Behavior<RibbonOptions> = {
   id: 'ribbon',
@@ -44,8 +44,9 @@ export const ribbon: Behavior<RibbonOptions> = {
    * The grid is sized by sampling this parameter from 0 to 1, so it has to
    * BE a 0..1 parameter (a `pool` that stops at 0.5 would be sampled across
    * a range it rejects), and it should be the one that drives the geometry
-   * hardest. `curl` sets the roll radius, sweeping it 0.5 -> 0.12, and the
-   * tightest radius is exactly the case that demands the most segments.
+   * hardest. `curl` opens the crease from a right angle to a fold back on
+   * itself, and the sharpest turn is exactly the case that demands the most
+   * segments across the hinge.
    */
   signature: ['pool', 'curl', 'drape'],
   progressParam: 'curl',
@@ -63,32 +64,57 @@ export const ribbon: Behavior<RibbonOptions> = {
     // whole drop from the ceiling down.
     const floorLine = -sheet.height / 2 + sheet.height * o.pool
 
+    // How soft the crease is. `curl` drives this rather than the fold angle
+    // — see the fold below for why.
+    const radius = Math.min(0.5, Math.max(0.02, sheet.height * (0.035 - o.curl * 0.027)))
+
+    /**
+     * The hinge does not turn on the spot: it wraps a cylinder of radius
+     * `radius / φ`, and the flap leaves that cylinder lower than the crease
+     * line by exactly that much.
+     *
+     * Which means placing the crease AT the floor buries the pool under it.
+     * That is what was happening — the pooled length came out about 9cm
+     * below the ground on the ribbon stage's own numbers, so the one thing
+     * the stage exists to show was inside the floor. The crease goes up by
+     * the hinge's own radius so that the POOL lands on the line, which is
+     * the thing that has to be true; where the crease sits is arithmetic.
+     */
+    const hingeDrop = radius / (Math.PI / 2)
+
     return [
       {
-        // `wave`, not `drape`, and that is a finding rather than a preference.
+        // `drape` — the deformer named after the thing this is.
         //
-        // `drape` is the obvious choice for folds down a hanging sheet, and
-        // it does not work here: it renders an invisible sheet on the hero
-        // (CPU) path at any grid, including an explicitly fixed one. It has
-        // only ever been reached through the field/GPU path — the stage
-        // banner is its single caller in the whole library — so nothing had
-        // ever run it on this side. Written up in docs/roadmap.md.
+        // It briefly used `wave` instead, to work around a report that
+        // `drape` rendered an invisible sheet on the hero path. That report
+        // was wrong: it rested on counting the colours in a screenshot, and
+        // a near-flat strip filling the frame has about as many colours as
+        // an empty one. `deformers/draws.test.ts` now asserts on geometry
+        // what the screenshot was being asked to guess at.
         //
-        // `wave` pinned at the top is the same picture by another road: the
-        // fold amplitude grows away from the fixing, which is what a strip
-        // hung from a clip does, and it is proven on both paths.
-        type: 'wave',
+        // `wave` was never the same picture. A wave is a sine of fixed
+        // amplitude end to end, so its folds ran just as deep at the clip as
+        // at the floor; a hung strip is FLAT where it is held and gathers as
+        // it falls, which is exactly `falloff`, and it narrows as it gathers,
+        // which is `gather`. Neither has an equivalent in `wave`.
+        type: 'drape',
         options: {
-          amplitude: o.drape * 0.06,
-          // Long and few. A printed strip carries two or three slow folds
+          // Depth at the free end. Larger than the wave's amplitude was,
+          // because this one starts at nothing under the clip rather than
+          // running at full depth the whole way down.
+          amplitude: o.drape * 0.1,
+          // Few and long. A printed strip carries two or three slow folds
           // down its drop; more than that is a curtain, not a ribbon.
-          wavelength: 0.62,
-          // Static — a hung strip is not a flag. `hang` is the behavior for
-          // paper that moves.
-          speed: 0,
-          // Across the width, so the folds run down the length.
-          angle: 8,
-          // Flat where the clip holds it, deepening toward the floor.
+          folds: 2.5,
+          // Holds the top flat and gathers the movement toward the floor,
+          // which is what a strip hung from a single clip does.
+          falloff: 1.5,
+          // Off a pure sine, so the folds do not read as corrugation.
+          irregular: 0.5,
+          // Gentle. The pooled length has to lie FLAT on the floor, and a
+          // hard pinch would narrow it as it went.
+          gather: 0.22,
           pinnedEdge: 'top',
         },
       },
@@ -106,16 +132,32 @@ export const ribbon: Behavior<RibbonOptions> = {
           // Travel measured down the drop, so the crease line sits across
           // the ribbon and the flap below it is what turns.
           angle: -90,
-          offset: -floorLine,
-          // A right angle lies the pool flat on the floor. Under that it is
-          // still coming down; over it, the paper has folded back on itself,
-          // which is what happens when more length arrives than there is
-          // floor to take it.
-          foldAngle: 62 + o.curl * 46,
-          // The hinge is soft and scales with the sheet: paper never creases
-          // to a mathematical edge, and a fixed radius that reads as a fold
-          // on a short strip reads as a knife-edge on a long one.
-          radius: Math.min(0.5, Math.max(0.02, sheet.height * 0.02)),
+          offset: -floorLine - hingeDrop,
+          // Exactly a right angle, at every setting, and this is the fix
+          // for the thing the ribbon stage was actually failing at.
+          //
+          // A hinge is one angle: whatever it turns through, the pooled
+          // length leaves the crease in a straight line and holds that
+          // heading. Only 90° is the floor. It shipped as `62 + curl * 46`
+          // (62°..108°), so below curl 0.61 the pool went on travelling
+          // downward and vanished THROUGH the floor — which is why the one
+          // stage built around this behavior rendered as flat strips
+          // stopping at the ground — and above it the pool tilted back UP
+          // and floated. Both halves of the range were wrong, in opposite
+          // directions, and only the midpoint was ever right.
+          //
+          // Paper with more length than floor does not rise at a constant
+          // angle; it buckles and lies in an S, which one hinge cannot
+          // describe and should not pretend to.
+          foldAngle: 90,
+          // So `curl` drives the CREASE instead, which is what its own
+          // description always claimed — "how tightly it turns where it
+          // lands. Low is a soft slump, high is a curl." A soft radius is a
+          // sheet slumping over the join; a tight one is a sheet that has
+          // been creased. It scales with the sheet, because a radius that
+          // reads as a fold on a short strip reads as a knife-edge on a long
+          // one.
+          radius,
         },
       },
     ]

--- a/packages/paperlab/src/deformers/draws.test.ts
+++ b/packages/paperlab/src/deformers/draws.test.ts
@@ -1,0 +1,154 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+import { computeSheetNormals } from '../core/normals'
+import { createSheetGeometry } from '../core/sheet'
+import { applyDeformerStack, stackAutoSegments, stackMinSegments } from './compose'
+import { getDeformer, listDeformers, resolveDeformerStack } from './registry'
+import type { DeformerInstance } from './types'
+import type { SheetConfig } from '../config/schema'
+
+/**
+ * Every deformer, built into a real sheet, actually draws one.
+ *
+ * This file exists because of a bug report that turned out to be wrong, and
+ * the reason it could stand for a day is the interesting part. `drape` was
+ * recorded as rendering an **invisible sheet** on the CPU path, on the
+ * evidence that a screenshot of it contained exactly one colour while the
+ * same frame of `roll` contained 698. `ribbon` was built around the finding
+ * — it uses `wave` where it means `drape` — and the roadmap carried it as an
+ * open bug.
+ *
+ * It does not reproduce. A drape at that size fills the frame with a nearly
+ * flat, nearly evenly lit surface, and **counting colours cannot tell that
+ * apart from an empty frame**. The measurement answered a different question
+ * from the one being asked.
+ *
+ * What the report got right is the gap it named: *"a parity gate proves the
+ * two implementations agree, not that either one draws."* Both halves of
+ * `drape` could have returned zero forever and every existing test would
+ * have passed — `drape.test.ts` checks `displace` at chosen uvs, and parity
+ * checks CPU against GPU. Nothing checked that the pipeline in between
+ * produces a surface.
+ *
+ * So this asserts the thing a screenshot was being used to guess at, on
+ * geometry rather than on pixels:
+ *
+ * - every vertex is finite,
+ * - the deformer *moved* the sheet (it is not silently a no-op),
+ * - the surface still HAS area — an isometric-ish bend keeps most of it, and
+ *   the failure this is really guarding against is total collapse,
+ * - the normals come out unit length, which is what a lit sheet needs to be
+ *   visible at all, and was the report's own leading suspicion.
+ *
+ * Run on a tall banner as well as an ordinary sheet, because the tall one is
+ * the shape that provoked the report, and because it is the shape where the
+ * two axes of the grid differ most.
+ */
+
+const SHEETS: { name: string; sheet: SheetConfig }[] = [
+  {
+    name: 'an ordinary sheet',
+    sheet: { width: 1, height: 1.4, thickness: 0.0012, segments: 'auto', cornerRadius: 0 },
+  },
+  {
+    // The ribbon stage's own banner — and the shape the false report was
+    // filed against.
+    name: 'a tall banner',
+    sheet: { width: 1.05, height: 9, thickness: 0.0012, segments: 'auto', cornerRadius: 0 },
+  },
+]
+
+/**
+ * Options that make each deformer visibly do something. Several ship
+ * defaults tuned for use *inside* a behavior, where another deformer is
+ * carrying the shape — those are honest defaults and a poor test subject.
+ */
+const STRENGTH: Record<string, Record<string, unknown>> = {
+  roll: { angle: 90, boundary: -0.1, radius: 0.12, spiral: 0.02 },
+  curl: { corner: 'bottom-right', amount: 0.6, radius: 0.25 },
+  bend: { curvature: 0.8, angle: 0 },
+  fold: { angle: 90, offset: 0.15, foldAngle: 110, radius: 0.06 },
+  wave: { amplitude: 0.09, wavelength: 0.4, speed: 0.9, angle: 75 },
+  drape: { amplitude: 0.3, folds: 6, falloff: 1.2, irregular: 0.5, gather: 0.6 },
+  crumple: { amount: 0.75, scale: 3, pull: 0.4, seed: 2 },
+}
+
+/** Build the sheet the way `<PaperMesh>` does, then deform it. */
+function build(sheet: SheetConfig, stack: DeformerInstance[]) {
+  const geometry = createSheetGeometry(sheet, stackMinSegments(stack, sheet), stackAutoSegments(stack, sheet))
+  const flat = Float32Array.from(geometry.attributes.position!.array as Float32Array)
+  applyDeformerStack(geometry, flat, stack, { t: 0.4, sheet })
+  computeSheetNormals(geometry)
+  return { geometry, flat }
+}
+
+/** Summed area of every triangle, which is what "there is a surface" means. */
+function surfaceArea(geometry: THREE.BufferGeometry): number {
+  const pos = geometry.attributes.position!.array as Float32Array
+  const idx = geometry.index!.array
+  const a = new THREE.Vector3()
+  const b = new THREE.Vector3()
+  const c = new THREE.Vector3()
+  let total = 0
+  for (let i = 0; i < idx.length; i += 3) {
+    a.fromArray(pos, idx[i]! * 3)
+    b.fromArray(pos, idx[i + 1]! * 3)
+    c.fromArray(pos, idx[i + 2]! * 3)
+    total += b.sub(a).cross(c.sub(a)).length() / 2
+  }
+  return total
+}
+
+describe('every deformer draws a sheet', () => {
+  for (const { name, sheet } of SHEETS) {
+    for (const id of listDeformers()) {
+      const stack = resolveDeformerStack([{ type: id, options: STRENGTH[id] ?? {} }])
+      const flatArea = sheet.width * sheet.height
+
+      it(`${id} on ${name}: every vertex is finite`, () => {
+        const { geometry } = build(sheet, stack)
+        const pos = geometry.attributes.position!.array as Float32Array
+        expect(pos.length).toBeGreaterThan(0)
+        expect(pos.every((v) => Number.isFinite(v))).toBe(true)
+      })
+
+      it(`${id} on ${name}: moves the sheet`, () => {
+        const { geometry, flat } = build(sheet, stack)
+        const pos = geometry.attributes.position!.array as Float32Array
+        const moved = pos.some((v, i) => Math.abs(v - flat[i]!) > 1e-6)
+        expect(moved, `${id} left the sheet exactly flat — it is a no-op here`).toBe(true)
+      })
+
+      it(`${id} on ${name}: leaves a surface behind`, () => {
+        const { geometry } = build(sheet, stack)
+        const area = surfaceArea(geometry)
+        // Paper bends without stretching, so a deformed sheet keeps most of
+        // its area; what this catches is collapse to nothing, which is what
+        // "renders an invisible sheet" would actually look like in geometry.
+        expect(area, `${id} collapsed the sheet: ${area} of ${flatArea}`).toBeGreaterThan(flatArea * 0.4)
+      })
+
+      it(`${id} on ${name}: has normals to light`, () => {
+        const { geometry } = build(sheet, stack)
+        const nrm = geometry.attributes.normal!.array as Float32Array
+        let unit = 0
+        for (let i = 0; i < nrm.length; i += 3) {
+          const len = Math.hypot(nrm[i]!, nrm[i + 1]!, nrm[i + 2]!)
+          expect(Number.isFinite(len)).toBe(true)
+          if (Math.abs(len - 1) < 1e-3) unit++
+        }
+        // A vertex whose faces cancel is left at zero on purpose (see
+        // computeSheetNormals) — a handful is fine, a sheet of them is not.
+        const total = nrm.length / 3
+        expect(unit / total, `${id}: only ${unit}/${total} vertices have a normal`).toBeGreaterThan(0.95)
+      })
+    }
+  }
+
+  it('covers every registered deformer, so a new one cannot skip this', () => {
+    for (const id of listDeformers()) {
+      expect(Object.keys(STRENGTH), `${id} has no strength entry in draws.test.ts`).toContain(id)
+    }
+    expect(getDeformer('drape')).toBeDefined()
+  })
+})

--- a/packages/paperlab/src/stage/PaperStage.tsx
+++ b/packages/paperlab/src/stage/PaperStage.tsx
@@ -130,10 +130,44 @@ export interface PaperStageProps extends PaperStageSceneProps {
 export function splitAcrossBanners(text: string, banners: number): string[] {
   const words = text.split(/\s+/).filter(Boolean)
   if (words.length === 0 || banners <= 0) return []
-  const per = Math.ceil(words.length / banners)
+  // Deal the words out rather than slicing at a fixed stride. `ceil` and a
+  // stride left the remainder on the floor: twenty words across twelve
+  // banners chunked by two produced TEN columns, and the last two banners
+  // hung blank in a stage that had asked for twelve. Dealing gives every
+  // banner a share and puts the odd words at the front, where a column one
+  // word longer than its neighbour reads as prose rather than as a mistake.
+  const each = Math.floor(words.length / banners)
+  const extra = words.length % banners
   const out: string[] = []
-  for (let i = 0; i < words.length; i += per) out.push(words.slice(i, i + per).join('\n'))
+  let at = 0
+  for (let i = 0; i < banners && at < words.length; i++) {
+    const take = each + (i < extra ? 1 : 0)
+    if (take === 0) break
+    out.push(words.slice(at, at + take).join('\n'))
+    at += take
+  }
   return out
+}
+
+/**
+ * Set a single word down the drop, one letter to a line.
+ *
+ * This is what the reference installations do, and it is what the stage was
+ * accidentally almost doing. Every built-in stage has FEWER words than
+ * banners — a nave of eighteen carries fifteen — so nearly every column is
+ * one word, and a one-word column asked for 150px type that no banner is
+ * wide enough to hold. `wrapLines` then broke it wherever the measure ran
+ * out, which turned "carried" into `ca / rr / ie / d`: vertical, full-drop,
+ * and unreadable as a word, because the break points were an accident of
+ * arithmetic rather than a decision.
+ *
+ * Breaking on purpose fixes both halves. One letter a line is legible as
+ * vertical setting, and it is the line COUNT that then sizes the type, so a
+ * long word gets small letters and a short word gets big ones — which is
+ * what makes a rank of banners look set rather than scaled.
+ */
+export function letterColumn(word: string): string {
+  return [...word].join('\n')
 }
 
 /**
@@ -146,9 +180,45 @@ export function splitAcrossBanners(text: string, banners: number): string[] {
  * size that lands the last line at the bottom of the paper. Clamped at both
  * ends: two words on an eight-metre drop should be enormous, but not so
  * enormous they crop, and a dense column still has to stay legible.
+ *
+ * **The drop is only half the constraint, and leaving the other half out was
+ * a real bug.** A banner is also NARROW, and the width was never consulted.
+ * On the ribbon stage — a 1.05 × 9 strip, so about 105px of measure once the
+ * margins are off — a two-word column asked for 150px type, every word came
+ * out wider than the sheet, `wrapLines` broke each one to a letter a line,
+ * and the column then overran the drop and was silently clipped. The frame
+ * showed one enormous letter per strip. So `measure` caps the size at
+ * something the longest word can actually sit on.
+ *
+ * The character estimate is exactly that — an estimate. Real advance widths
+ * need a canvas, which is not available where this is decided, so 0.62em is
+ * used as a deliberately generous average for a mixed-case serif: erring
+ * high makes the type a little small, and erring low brings back the letter
+ * a line. `wrapLines` is still the backstop for a word no size can fit.
  */
-export function bannerTextSize(lines: number): number {
-  return Math.round(Math.min(150, Math.max(26, 720 / Math.max(lines, 1))))
+export function bannerTextSize(lines: number, longestWord = 0, measure = Number.POSITIVE_INFINITY): number {
+  const byDrop = 720 / Math.max(lines, 1)
+  const byMeasure = longestWord > 0 ? measure / (longestWord * 0.62) : Number.POSITIVE_INFINITY
+  // Floor, not round: rounding UP is how a size that was computed to fit
+  // stops fitting, and half a pixel of type is worth nobody's attention.
+  return Math.floor(Math.min(150, Math.max(26, Math.min(byDrop, byMeasure))))
+}
+
+/** The inset the banner column is set inside, on both the sizer and the painter. */
+const PADDING = 0.06
+
+/**
+ * The usable width of a banner's texture, in the units `content.size` is in.
+ *
+ * Both numbers here are facts about how content is painted, not choices:
+ * the canvas is `LONG_EDGE` on its long side, and `paintText` insets by
+ * `padding` of the SHORT side. Stated once so the type sizer and the painter
+ * cannot drift apart about how much room there is.
+ */
+export function bannerMeasure(sheet: { width: number; height: number }, padding = PADDING): number {
+  const long = Math.max(sheet.width, sheet.height)
+  if (!(long > 0)) return Number.POSITIVE_INFINITY
+  return (sheet.width / long) * 1024 * (1 - padding * 2)
 }
 
 /**
@@ -331,25 +401,46 @@ export function PaperStageScene({
     if (papers) return papers
     if (images) return undefined
     if (text !== undefined) {
-      const columns = Array.isArray(text) ? text : splitAcrossBanners(text, count)
+      const split = Array.isArray(text) ? text : splitAcrossBanners(text, count)
+      // A whole-rank decision, not a per-banner one: if there is at most one
+      // word for every banner, the stage is set vertically. Mixing the two
+      // would put one banner's letters next to another's words at a single
+      // shared size, and one of the two would always be wrong.
+      const vertical = split.every((c) => !c.includes('\n'))
+      const columns = vertical ? split.map(letterColumn) : split
       const longest = columns.reduce((n, c) => Math.max(n, c.split('\n').length), 1)
-      const size = bannerTextSize(longest)
+      // The longest WORD, not the longest line: lines are already one word
+      // each, and it is the word that has to fit across the strip.
+      const longestWord = columns.reduce(
+        (n, c) => c.split('\n').reduce((m, w) => Math.max(m, w.length), n),
+        1,
+      )
+      const size = bannerTextSize(longest, longestWord, bannerMeasure(sheetDims, PADDING))
       return columns.map((column) => ({
         content: {
           type: 'text',
           text: column,
           size,
           align: 'center',
+          // Centred down the drop as well as across it. One size is shared
+          // by the whole rank — that is what makes it read as set rather
+          // than scaled — so a short word necessarily leaves slack, and the
+          // slack belongs at both ends. Hung from the top instead, "the"
+          // reads as a caption that ran out while "remembers" fills its
+          // banner, and the rank looks broken rather than composed.
+          valign: 'center',
           color: '#241f1a',
           lineHeight: 1.25,
           font: 'Georgia, "Times New Roman", serif',
           weight: 400,
-          padding: 0.06,
+          padding: PADDING,
         } satisfies ContentConfigInput,
       }))
     }
     return Array.from({ length: count }, () => ({}))
-  }, [papers, images, text, count])
+    // `sheetDims` belongs here: the type size is capped by how wide the
+    // banner is, so a preset that changes the sheet has to re-set the type.
+  }, [papers, images, text, count, sheetDims])
 
   const drive = stageMotionSchema.parse(motion ?? {})
 

--- a/packages/paperlab/src/stage/camera.test.ts
+++ b/packages/paperlab/src/stage/camera.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createWalkPath, walkPathSchema } from './path'
 import { DEFAULT_PAPER_RATIO, shotSchema, stageCamera, walkPoint } from './camera'
-import { bannerTextSize, splitAcrossBanners } from './PaperStage'
+import { bannerMeasure, bannerTextSize, splitAcrossBanners } from './PaperStage'
 
 const HEIGHT = 1.75
 const path = (o: Record<string, unknown> = {}) => createWalkPath(walkPathSchema.parse(o))
@@ -187,5 +187,67 @@ describe('banner typography', () => {
   it('survives text with nothing in it', () => {
     expect(splitAcrossBanners('   ', 8)).toEqual([])
     expect(splitAcrossBanners('word', 0)).toEqual([])
+  })
+
+  /**
+   * A stage that asks for twelve banners and is handed a paragraph must get
+   * twelve columns. Slicing at `ceil(words / banners)` left the remainder
+   * unallocated — the ribbon stage's twenty words over twelve banners
+   * produced ten columns, and two banners hung blank.
+   */
+  it('gives every banner a share, however the words divide', () => {
+    for (const banners of [3, 5, 7, 12, 20]) {
+      const words = Array.from({ length: 20 }, (_, i) => `w${i}`).join(' ')
+      const columns = splitAcrossBanners(words, banners)
+      expect(columns, `${banners} banners`).toHaveLength(Math.min(banners, 20))
+      // Nothing dropped, nothing duplicated.
+      expect(columns.join('\n').split('\n')).toHaveLength(20)
+    }
+  })
+
+  it('never leaves a banner one word while another carries three', () => {
+    const columns = splitAcrossBanners('a b c d e f g h i j', 4)
+    const lengths = columns.map((c) => c.split('\n').length)
+    expect(Math.max(...lengths) - Math.min(...lengths)).toBeLessThanOrEqual(1)
+  })
+
+  it('has fewer columns than banners only when there are fewer words', () => {
+    expect(splitAcrossBanners('one two', 9)).toHaveLength(2)
+  })
+
+  /**
+   * The bug this pair guards: the sizer knew how tall a banner was and not
+   * how WIDE. On the ribbon stage's 1.05 x 9 strip it asked for 150px type
+   * on about 105px of measure, so every word broke to one letter a line and
+   * the column then overran the drop and was clipped. The frame showed a
+   * single enormous letter per strip.
+   */
+  it('caps the size at something the longest word can sit on', () => {
+    const strip = bannerMeasure({ width: 1.05, height: 9 })
+    // Two words on a nine-metre drop still wants 150 on the drop alone…
+    expect(bannerTextSize(2)).toBe(150)
+    // …and cannot have it on a strip this narrow.
+    const sized = bannerTextSize(2, 'paper'.length, strip)
+    expect(sized).toBeLessThan(150)
+    expect(sized * 'paper'.length * 0.62).toBeLessThanOrEqual(strip)
+  })
+
+  it('leaves a wide banner alone — the width only binds when it is the tighter limit', () => {
+    // 520px of measure holds a four-letter word at the drop's own 120px.
+    const wide = bannerMeasure({ width: 1.5, height: 2.6 })
+    expect(bannerTextSize(6, 4, wide)).toBe(bannerTextSize(6))
+    // …and a long word on the same banner is still capped, because the
+    // constraint is the word, not the shape.
+    expect(bannerTextSize(6, 12, wide)).toBeLessThan(bannerTextSize(6))
+  })
+
+  it('still answers without a measure, so an old call site keeps its size', () => {
+    expect(bannerTextSize(6)).toBe(bannerTextSize(6, 0, 10))
+  })
+
+  it('measures the strip inside its margins, not edge to edge', () => {
+    // 1024 on the long edge, inset 6% of the short side at each margin.
+    expect(bannerMeasure({ width: 1.05, height: 9 })).toBeCloseTo((1.05 / 9) * 1024 * 0.88, 6)
+    expect(bannerMeasure({ width: 0, height: 0 })).toBe(Number.POSITIVE_INFINITY)
   })
 })

--- a/packages/paperlab/src/stage/presets.ts
+++ b/packages/paperlab/src/stage/presets.ts
@@ -183,8 +183,31 @@ export const stagePresets: Record<string, StagePreset> = {
       surface: { grain: 0.2 },
       behavior: { type: 'ribbon', pool: 0.22, curl: 0.34, drape: 0.6 },
     },
-    count: 12,
-    text: 'the paper kept going long after the floor ran out from under it and nobody moved to pick it up',
+    // Eight, not twelve, and the reason is the type rather than the room.
+    // A strip 1.05 wide holds about 105px of measure, which caps the type at
+    // 26px, which means a column needs roughly twenty-six words to reach the
+    // bottom of a nine-metre drop. Twelve strips wanted three hundred words;
+    // eight want two hundred, which is a passage rather than an essay. Fewer
+    // and longer is also what the reference installations look like.
+    count: 8,
+    // Long, because the whole point of this stage is type running the length
+    // of the paper. It shipped with twenty words across twelve banners — two
+    // words a strip — which set as a caption at the top of nine metres of
+    // blank paper. Every word here is kept to seven letters or fewer: the
+    // measure is narrow, and one long word shrinks the type on every banner
+    // in the room, because a rank of banners is set at one size or it reads
+    // as a mistake.
+    text:
+      'the paper kept going long after the floor ran out from under it and nobody moved to pick it up ' +
+      'we let it lie there the way you let a letter lie it had come down from a height no one could name ' +
+      'and it held the shape of the fall in its folds someone inked it once and you can still read the ' +
+      'last of it where the light gets in a room is only a room until you hang a thing in it then it is ' +
+      'a place you walk across slowly the strips move when the door opens and settle again before you ' +
+      'reach them paper holds what it was rolled around it holds being flat too and it will go back to ' +
+      'flat if you leave it alone long enough but not today today it lies in a curve at the foot of the ' +
+      'wall and the curve is the whole point the floor was never meant to hold this much so the paper ' +
+      'takes over where the floor gives up it pools the way water would if water could be inked we came ' +
+      'to look at the light we stayed for the paper on the ground',
   },
   archive: {
     id: 'archive',


### PR DESCRIPTION
An audit of phases 01–06 against the build order, and the fixes it turned up. **Phase 05 is the one that had not been looked at closely enough** — the ribbon stage did not render the thing it exists for.

## The ribbon stage's pool did not exist

Three defects, two of them in the same eight lines.

**The crease could not reach a right angle.** `foldAngle` was `62 + curl * 46` — 62°..108°. A hinge turns through one angle and the pooled length holds that heading from the crease onward, so **only a right angle is the floor**: under it the pool keeps descending and goes through the ground, over it the pool tilts back up and floats. The behavior's default (0.45) and the stage preset's own value (0.34) were **both under**. Fixed at 90; `curl` now drives the crease RADIUS, which is what its own description always claimed.

**The crease was placed as if the hinge had no size.** It wraps a cylinder of `radius / φ`, so the flap leaves it that much lower than the crease line — measured at ~9cm below the floor on the stage's own numbers. The crease goes up by the hinge's radius, because what has to land on the floor is the pool.

**It used `wave` where it meant `drape`.** See below. `wave` was never the same picture: a sine runs at one amplitude end to end, and a hung strip is flat where it is held and gathers as it falls — `falloff` — and narrows as it gathers — `gather`. Neither exists in `wave`.

## The `drape` bug does not reproduce

The roadmap carried it as open, on the evidence that a screenshot contained **exactly one colour** where `roll` contained 698. Re-run against every case the report named — the reported 0.85 × 6.4 sheet, the ribbon's 1.05 × 9 banner, an explicit `segments: 96`, a square sheet, the option range at its extremes — `drape` draws every time.

**Counting colours cannot tell an empty frame from one flat surface filling it.** A tall drape at that scale is a nearly flat, evenly lit white plane; a roll is a cylinder.

What the report got right is the gap it named — *"a parity gate proves the two implementations agree, not that either one draws"* — and that gap was real. Both halves of `drape` could have returned zero forever and every test would have passed. **`deformers/draws.test.ts`** closes it: every registered deformer, on two aspect ratios, built through the real pipeline and asserted finite, actually moved, still holding most of its area, and carrying unit normals. Verified to fail by collapsing `drape` on purpose; the last case asserts the table covers the registry so a new deformer cannot skip it.

## Banner type was sized by the drop and never by the measure

On the ribbon's 1.05 × 9 strip — ~105px of measure — a two-word column asked for 150px type, every word came out wider than the sheet, `wrapLines` broke each one wherever the measure ran out, and the column then overran the drop and was silently clipped. **One enormous letter per strip.**

Fixing the cap exposed the bigger thing: **every built-in stage has fewer words than banners** (a nave of eighteen carries fifteen), so nearly every column is a single word, and the old code "filled" the drop by shattering it — `carried` as `ca / rr / ie / d`.

- **`letterColumn`** sets a single word one letter to a line on purpose. A whole-rank decision (`words <= banners`), because letters and words at one shared size would always be wrong for one of them.
- **The measure caps the size** (`bannerMeasure` states how much room there is, once).
- **`valign: 'center'`** — one size is shared by the rank, so the slack belongs at both ends.
- **`splitAcrossBanners` dropped banners**: a fixed `ceil(words/banners)` stride gave ten columns for twelve banners. It deals the words out now.
- The ribbon stage got a passage instead of a caption, sized by the arithmetic: ~26 words fill a nine-metre drop at the measure's cap, so eight strips and two hundred words, every word ≤7 letters — one long word shrinks the type on every banner in the room.

## Editor

The three remaining `inspectorEpoch` bumps that only change values are gone — `clearStateOverride`, `resetStateOverrides`, `clearSlotState` — for the same reason as the drop-zone one in #35: you open a folder to find the control you want to reset, and resetting it closed the folder.

## Audit result, recorded in the roadmap

**The build order finally lands in `docs/roadmap.md`** — a Phase 00 task that stayed open through five phases, and the reason these gaps could not be checked against the repo.

Phases 01, 02, 06 verified done. Phase 05 done after the above. Two phases shipped less than the plan asked, and neither had been written down:

- **Phase 03** asked for a ceiling, a column with a base plate, a doorway, floor slab seams, and a wall corner. Two shipped. **Not fixed here** — new scene geometry is a feature, not a fix, and I would rather it be a decision than a late add. The column is the strongest of the three missing, and is worth having before launch assets are shot.
- **Phase 04** asked for "thread, clips, pegs, a rod". Thread and clips shipped. Defensible as it stands; the rod is what the phase-08 canopy stage will want.

## Verified

All eight gates: lint, knip, typecheck, test (662), build, `check:package`, `test:parity` (37/37), `test:drive`. Every stage re-rendered and compared against its pre-change frame — the four that share the banner typesetting (`nave`, `procession`, `cloister`, `archive`, `threshold`) read better, not just differently.