### PR TITLE
chore(paperlab): a changeset, so npm stops serving the old page

### DIFF
--- a/.changeset/the-page-npm-shows.md
+++ b/.changeset/the-page-npm-shows.md
@@ -1,0 +1,23 @@
+---
+'paperlab': patch
+---
+
+The npm page now shows the library that actually shipped.
+
+No code changes: the tarball's only difference is `README.md`, which npm serves
+as the package page and which had drifted badly from 0.3.0. It documented a peer
+floor of `three >= 0.160` where the package requires `>= 0.162`; it never once
+mentioned `<PaperMesh>`; it described deformers, content types and interaction
+states nowhere on the page; and every moving image on it predated both the
+current design language and the switch of demo content to paper artifacts, so
+the pictures were selling a product that no longer looked like that.
+
+It also linked to a planning document that has been removed from the repository,
+which on npm is a dead link with nothing behind it.
+
+The page now carries the catalogues rather than describing them — the six stage
+presets, twelve field layouts, eight lighting rigs and seven paper stocks, each
+photographed side by side, because a catalogue only means anything when you can
+compare its entries. Every asset is regenerated from the registries by
+`pnpm media`, `pnpm shot:catalogue` and `pnpm sheet`, so the page cannot
+silently drift from the library again.


### PR DESCRIPTION
`README.md` ships in the tarball and npm renders it as the package page. That page has been the pre-rewrite copy since 0.3.0 — it documents `three >= 0.160` against a package requiring `>= 0.162`, never mentions `<PaperMesh>`, omits deformers and interaction states entirely, shows images from before the current design language, and links to a planning document that no longer exists in the repo.

**Patch, not minor.** The only file that differs in the published tarball is the README. I diffed `paperlab@0.3.0..main` across `packages/paperlab/src` — every other change is a comment, except four `it()` / `describe()` **names**, and tests are not published.

Merging this opens the usual Version Packages PR for 0.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)