### PR TITLE
refactor(paperlab)!: the public API is 83 names, not 214

### DIFF
--- a/.changeset/the-inside-of-the-box.md
+++ b/.changeset/the-inside-of-the-box.md
@@ -1,0 +1,40 @@
+---
+'paperlab': minor
+---
+
+**Breaking: the public API is 83 names instead of 214.**
+
+Every exported name is a promise kept for years, and this library was exporting
+its own internals: shader builders (`buildFieldVertexShader`,
+`buildDisplacementGLSL`), texture painters (`barcodeBars`, `makeGoboTexture`,
+`silhouetteRects`), tessellation constants (`SHEET_LIFT`, `TRANSMISSION_GAIN`),
+the cloth integrator, the state machine class, and 36 individual behavior,
+deformer and layout functions that the registries already reach.
+
+None of that is API. It is the inside of the box, and shipping it means a
+refactor of a private helper becomes a breaking change for somebody. The
+surface is now what a caller genuinely needs: the four components, the schema
+and its types, the registries and their three `register*` hooks, presets and
+the `.paper` file format, the export helpers, lighting-as-data, interaction
+states, and the accessibility utilities.
+
+**Behaviors, deformers and layouts are reached through their registries.**
+`getBehavior('peel')`, `getDeformer('roll')` and `getLayout('ring')` return
+exactly what the removed named exports did, and `listBehaviors()`,
+`listDeformers()` and `listLayouts()` enumerate them. Nothing was deleted from
+the library — only from its front door.
+
+Three things that look internal are still exported, each with the reasoning
+written where it is exported: the GPU/CPU **parity harness**, because it is the
+only gate on the invariant the contribution ladder rests on; the **tessellation
+arithmetic**, because `registerDeformer` is public and a third-party deformer
+must answer the segment-count question the same way the built-in seven do; and
+**`wrapLines`**, because a caller measuring type before laying out a sheet has
+to get the same answer the painter will.
+
+`paperlab/stage` loses seven names the same way — a magic constant, four
+sub-schemas, and two export helpers — keeping the sixteen that `llms.txt`
+documents.
+
+This lands now, at 0.4.0, precisely because nobody has built on the old surface
+yet. Doing it later would cost real users a migration for no benefit to them.

--- a/packages/paperlab/src/PaperField.tsx
+++ b/packages/paperlab/src/PaperField.tsx
@@ -21,29 +21,18 @@ import { useStable } from './core/stable'
 import type { SheetLayoutOptions } from './field/sheetGrid'
 import { fitCamera, resolveLayoutOptions } from './field/framing'
 
-// The field system lives in field/*; this module is the public composition.
-// Re-exported here so `import { … } from './PaperField'` (index.ts, tests,
-// consumers) keeps working across the split.
+// The field system lives in field/*; this module is the public composition,
+// so it forwards only what the public API names. The rest of field/* is
+// reachable from its own module for tests and for the internals — it is not
+// re-exported here, because a re-export is how something becomes public by
+// accident.
 export {
   DropZone,
-  DropZoneRegistry,
-  zoneAccepts,
   type DropZoneConfig,
   type DropZoneProps,
   type PlacedPaper,
 } from './field/dropZones'
-export {
-  groupFieldPapers,
-  resolveFieldSlotConfig,
-  type FieldPaperSlot,
-  type FieldGroupData,
-} from './field/slots'
-export type { FieldA11yController } from './field/interactiveField'
-export {
-  fieldKeyboardStep,
-  type KeyboardCarry,
-  type KeyboardStepResult,
-} from './field/keyboardMirror'
+export type { FieldPaperSlot } from './field/slots'
 
 export interface PaperFieldMeshProps {
   /** Per-paper slots; length sets the instance count. Slot presets override the shared one. */

--- a/packages/paperlab/src/config/field-export.test.ts
+++ b/packages/paperlab/src/config/field-export.test.ts
@@ -9,7 +9,8 @@ import {
 } from './field-export'
 import { AGENT_PAYLOAD_VERSION } from './agent-payload'
 import { getPreset } from './presets'
-import { groupFieldPapers, zoneAccepts } from '../PaperField'
+import { groupFieldPapers } from '../field/slots'
+import { zoneAccepts } from '../field/dropZones'
 
 const photo = getPreset('photo-print')
 const receipt = getPreset('receipt-unroll')

--- a/packages/paperlab/src/field/keyboard.test.ts
+++ b/packages/paperlab/src/field/keyboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fieldKeyboardStep, type FieldA11yController } from '../PaperField'
+import { fieldKeyboardStep } from './keyboardMirror'
+import type { FieldA11yController } from './interactiveField'
 import { PaperStateMachine } from '../states/machine'
 import { paperConfigSchema, type PaperConfig } from '../config/schema'
 

--- a/packages/paperlab/src/index.ts
+++ b/packages/paperlab/src/index.ts
@@ -1,49 +1,51 @@
+/**
+ * The public API.
+ *
+ * Everything named here is a promise: once it is on npm, taking it away costs
+ * whoever imported it a migration. So the bar is not "is this useful?" but
+ * "would I support this for years?" — and the answer for a shader builder, a
+ * texture painter or a tessellation constant is no. Those are the inside of
+ * the box, and the box is `<Paper>`, `<PaperField>`, `<PaperStage>` and the
+ * data that describes them.
+ *
+ * Three things survive that bar despite looking internal, each for a reason
+ * written where it is exported: the parity harness, the tessellation
+ * arithmetic, and line breaking. Each is the answer to a question a caller
+ * can genuinely ask and cannot otherwise answer.
+ *
+ * Adding a name here later is free. Removing one is not. When in doubt, leave
+ * it out.
+ */
+
+// ── The components ──────────────────────────────────────────────────────────
+
 export { Paper, type PaperProps } from './Paper'
+export { PaperMesh, type PaperMeshProps, type PaperHandle } from './PaperMesh'
 export {
   PaperField,
   PaperFieldMesh,
-  groupFieldPapers,
-  resolveFieldSlotConfig,
-  fieldKeyboardStep,
   DropZone,
-  DropZoneRegistry,
-  zoneAccepts,
   type PaperFieldProps,
   type PaperFieldMeshProps,
   type FieldPaperSlot,
-  type FieldGroupData,
   type DropZoneConfig,
   type DropZoneProps,
   type PlacedPaper,
-  type FieldA11yController,
-  type KeyboardCarry,
-  type KeyboardStepResult,
 } from './PaperField'
-export { PaperMesh, resolveConfig, type PaperMeshProps, type PaperHandle } from './PaperMesh'
+
+// ── The schema. It is the spec: if it cannot serialize, it does not ship. ───
 
 export {
   paperConfigSchema,
-  sheetSchema,
-  stockSchema,
-  contentSchema,
-  backContentSchema,
   behaviorConfigSchema,
-  deformerInstanceSchema,
-  surfaceSchema,
-  cardContentSchema,
-  receiptContentSchema,
-  physicsSchema,
   clothConfigSchema,
+  paperStatesSchema,
+  stateDefSchema,
   physicsNames,
-  sceneSchema,
   lightingNames,
-  filmNames,
   stockNames,
   paperEdges,
   coreStateNames,
-  stateDefSchema,
-  stateTransitionSchema,
-  paperStatesSchema,
   type PaperConfig,
   type PaperConfigInput,
   type SheetConfig,
@@ -73,127 +75,71 @@ export {
   type PaperStatesInput,
 } from './config/schema'
 
-export {
-  PaperStateMachine,
-  stateEventTransitions,
-  resolveStateConfig,
-  recordStateOverride,
-  stripStates,
-  flattenNumeric,
-  type StateEvent,
-  type PaperStateMachineOptions,
-} from './states/machine'
-export { usePaperStates, type UsePaperStatesResult } from './states/usePaperStates'
+export { sheetLayoutSchema, type SheetLayoutOptions } from './field/sheetGrid'
+
+// ── Presets, and the file format ────────────────────────────────────────────
 
 export {
-  sheetLayoutSchema,
-  sheetSlotXY,
-  sheetBackingSize,
-  outwardCorner,
-  tornEdgesOnDetach,
-  withSheetCellFromPaper,
-  SHEET_LIFT,
-  type SheetLayoutOptions,
-} from './field/sheetGrid'
-export { drawBacking, silhouetteRects, lightenHex, type BackingDrawSpec } from './content/backing'
+  getPreset,
+  listPresets,
+  registerPreset,
+  unregisterPreset,
+  isBuiltinPreset,
+  uniquePresetName,
+} from './config/presets'
+export { parsePreset, serializePreset, mergeConfig, mergeWithDeletes } from './config/serialize'
+export { diffConfig, buildJsxSnippet } from './config/diff'
+
+// ── Export: the brief an agent or a codebase receives ───────────────────────
+
+export { buildAgentPayload, describeConfig } from './config/agent-payload'
+export {
+  buildFieldAgentPayload,
+  buildFieldComponentSource,
+  describeFieldConfig,
+  diffFieldProps,
+  type FieldExportInput,
+  type FieldExportPaper,
+  type FieldExportZone,
+} from './config/field-export'
+
+// ── The registries, and the three ways to extend them ───────────────────────
+
+export type { Deformer, DeformerInstance, DeformerContext, SheetDims } from './deformers/types'
+export { registerDeformer, getDeformer, listDeformers } from './deformers/registry'
+export type { Behavior, HandleSpec } from './behaviors/types'
+export { registerBehavior, getBehavior, listBehaviors } from './behaviors/registry'
+export { getLayout, listLayouts, registerLayout, type Layout, type PaperPose } from './field/layouts'
+export { stocks, getStock, type Stock } from './core/stock'
+export { idleNames, type IdleName, type IdlePreset } from './physics/idle'
+
+// ── Lighting is data, not an enum ───────────────────────────────────────────
 
 export {
-  lightingPresets,
-  getLightingPreset,
-  type LightingPreset,
-  // Lighting as data: a preset is the starting point and these are the
-  // overrides that ride on it.
   lightSchema,
   resolveLighting,
   lightAngles,
-  lightPosition,
+  type LightingPreset,
   type LightAngles,
   type LightOverrides,
   type LightOverridesInput,
 } from './scene/lighting'
-export { PaperLighting, makeGoboTexture, type PaperLightingProps } from './scene/PaperLighting'
+export { PaperLighting, type PaperLightingProps } from './scene/PaperLighting'
 // Publish a resolved rig to the paper under it, so a hand-lit scene's
 // transmission agrees with its lamps. `<PaperStage>` does this for you.
 export { LightRig } from './scene/rig'
 
-export type { Deformer, DeformerInstance, DeformerContext, SheetDims } from './deformers/types'
-export {
-  registerDeformer,
-  getDeformer,
-  listDeformers,
-  resolveDeformerStack,
-} from './deformers/registry'
-export {
-  applyDeformerStack,
-  displacePoint,
-  stackAutoSegments,
-  stackMinSegments,
-} from './deformers/compose'
-export { roll, rollOptionsSchema, type RollOptions } from './deformers/roll'
-export { curl, curlOptionsSchema, cornerNames, type CurlOptions } from './deformers/curl'
-export { bend, bendOptionsSchema, type BendOptions } from './deformers/bend'
-export { fold, foldOptionsSchema, type FoldOptions } from './deformers/fold'
-export { wave, waveOptionsSchema, type WaveOptions } from './deformers/wave'
-export { drape, drapeOptionsSchema, type DrapeOptions } from './deformers/drape'
-export { crumple, crumpleOptionsSchema, type CrumpleOptions } from './deformers/crumple'
+// ── Interaction states ──────────────────────────────────────────────────────
 
-export type { Behavior, HandleSpec } from './behaviors/types'
-export { registerBehavior, getBehavior, listBehaviors } from './behaviors/registry'
-export { peel, peelOptionsSchema, type PeelOptions } from './behaviors/peel'
-export { unroll, unrollOptionsSchema, type UnrollOptions } from './behaviors/unroll'
-export { flip, flipOptionsSchema, type FlipOptions } from './behaviors/flip'
-export { letterFold, letterFoldOptionsSchema, type LetterFoldOptions } from './behaviors/letter-fold'
-export { hang, hangOptionsSchema, type HangOptions } from './behaviors/hang'
-export { fly, flyOptionsSchema, type FlyOptions } from './behaviors/fly'
-export { fall, fallOptionsSchema, type FallOptions } from './behaviors/fall'
-export { settle, settleOptionsSchema, type SettleOptions } from './behaviors/settle'
-export { ribbon, ribbonOptionsSchema, type RibbonOptions } from './behaviors/ribbon'
-export { carry, carryOptionsSchema, type CarryOptions } from './behaviors/carry'
-export { flight, flightOptionsSchema, type FlightOptions } from './behaviors/flight'
-// The first behavior whose name is already taken by the deformer it drives.
-// Both are `crumple` to their own registries; only the JS binding has to give.
-export {
-  crumpleBehavior,
-  crumpleBehaviorOptionsSchema,
-  type CrumpleBehaviorOptions,
-} from './behaviors/crumple'
+export { resolveStateConfig, recordStateOverride, type StateEvent } from './states/machine'
+export { usePaperStates, type UsePaperStatesResult } from './states/usePaperStates'
 
-export { idlePresets, getIdlePreset, idleNames, type IdleName, type IdlePreset } from './physics/idle'
+// ── Accessibility ───────────────────────────────────────────────────────────
 
-export {
-  buildDisplacementGLSL,
-  buildFieldVertexShader,
-  buildFieldFragmentShader,
-  stackUniformValues,
-  type ComposedDisplacement,
-} from './field/compose'
-export {
-  getLayout,
-  listLayouts,
-  registerLayout,
-  ring,
-  fan,
-  spread,
-  pile,
-  wall,
-  spill,
-  sweep,
-  book,
-  accordion,
-  rack,
-  colonnade,
-  sheet,
-  type Layout,
-  type PaperPose,
-} from './field/layouts'
-export { fieldBounds, fitCamera, type FieldBounds } from './field/framing'
-export {
-  translucencyUniforms,
-  translucencyValues,
-  TRANSMISSION_GAIN,
-  type TranslucencyValues,
-} from './surface/translucency'
-export { useContentAtlas, atlasGrid, type ContentAtlas } from './content/atlas'
+export { usePrefersReducedMotion, supportsWebGL } from './a11y'
+
+// ── The three that look internal and are not ────────────────────────────────
+
 /**
  * The GPU/CPU parity harness — public on purpose, and the reasoning is worth
  * writing down because it reads like test infrastructure that leaked.
@@ -218,65 +164,13 @@ export {
   type ParityCase,
   type ParityResult,
 } from './field/parity'
-export { ClothSim, type ClothParams, type PinMode } from './physics/cloth'
-export {
-  dampTo,
-  gust,
-  flightPose,
-  carryDrive,
-  type AeroPose,
-  type DampedValue,
-  type FlightParams,
-} from './physics/aero'
 
-export { composeSurface, type ComposedSurface, type SurfaceMaps } from './surface/compose'
-export { PaperMaterial, type PaperMaterialProps } from './surface/PaperMaterial'
-export { receiptTotals, barcodeBars, type ReceiptContent } from './content/receipt'
-export type { CardContent } from './content/card'
-// Line breaking is exported because it is the answer to "where does this
-// wrap", and a caller measuring a block of type before laying a sheet out
-// has to get the same answer the painter will.
-export { wrapLines } from './content/type'
-
-export { parsePreset, serializePreset, mergeConfig, mergeWithDeletes } from './config/serialize'
-export { diffConfig, buildJsxSnippet } from './config/diff'
-export {
-  buildAgentPayload,
-  describeConfig,
-  AGENT_PAYLOAD_VERSION,
-} from './config/agent-payload'
-export {
-  buildFieldAgentPayload,
-  buildFieldComponentSource,
-  describeFieldConfig,
-  diffFieldProps,
-  distinctFieldPresets,
-  type FieldExportInput,
-  type FieldExportPaper,
-  type FieldExportZone,
-} from './config/field-export'
-export {
-  usePrefersReducedMotion,
-  supportsWebGL,
-  contentText,
-  PaperMirror,
-  PaperFallback,
-} from './a11y'
-export { quantizeTime, quantizeProgress, ON_TWOS_FPS } from './motion/onTwos'
-export {
-  getPreset,
-  listPresets,
-  registerPreset,
-  unregisterPreset,
-  isBuiltinPreset,
-  uniquePresetName,
-} from './config/presets'
-export { stocks, getStock, type Stock } from './core/stock'
-export { createSheetGeometry, resolveSegments } from './core/sheet'
-// The arithmetic behind `geometry.autoSegments`. Public because
-// `registerDeformer` is: a deformer someone else writes has to be able to
-// answer the same question the built-in seven answer, and the answer should
-// be the same formula rather than a guess at what the library does.
+/**
+ * The arithmetic behind `geometry.autoSegments`. Public because
+ * `registerDeformer` is: a deformer someone else writes has to be able to
+ * answer the same question the built-in seven answer, and the answer should
+ * be the same formula rather than a guess at what the library does.
+ */
 export {
   AUTO_CEILING,
   FLAT_SEGMENTS,
@@ -286,4 +180,10 @@ export {
   segmentsForSine,
   spanAlong,
 } from './core/tessellation'
-export { resolveMode, type PaperMode, type PaperModeRequest } from './core/modes'
+
+/**
+ * Line breaking is exported because it is the answer to "where does this
+ * wrap", and a caller measuring a block of type before laying a sheet out
+ * has to get the same answer the painter will.
+ */
+export { wrapLines } from './content/type'

--- a/packages/paperlab/src/stage.ts
+++ b/packages/paperlab/src/stage.ts
@@ -26,18 +26,14 @@ export {
   type PaperStageProps,
   type PaperStageSceneProps,
 } from './stage/PaperStage'
-export { SOURCE_INTENSITY } from './stage/Surround'
 export {
   stageSchema,
-  stageGradeSchema,
-  stageRoomSchema,
-  stageSuspensionSchema,
   type StageConfig,
   type StageConfigInput,
   type StageGradeConfig,
 } from './stage/schema'
 // Who drives the walk — the same three names a field's motion uses.
-export { stageMotionSchema, type StageMotion, type StageMotionInput } from './stage/navigate'
+export type { StageMotion, StageMotionInput } from './stage/navigate'
 export { stagePresets, getStagePreset, listStagePresets, type StagePreset } from './stage/presets'
 export { walks, walkNames, getWalk, type WalkName } from './stage/walks'
 export { createWalkPath, type Ground, type WalkPath, type WalkPathOptions } from './stage/path'
@@ -50,7 +46,5 @@ export {
   buildStageComponentSource,
   describeStage,
   diffStage,
-  walkNameFor,
-  stringifyStage,
   type StageExportInput,
 } from './stage/export'


### PR DESCRIPTION
Every exported name is a promise kept for years. This library was exporting its own internals — and shipping them means a refactor of a private helper becomes somebody's breaking change.

**214 → 83 runtime exports** (`paperlab` 191 → 67, `paperlab/stage` 23 → 16).

## What left

Shader builders (`buildFieldVertexShader`, `buildDisplacementGLSL`), texture painters (`barcodeBars`, `makeGoboTexture`, `silhouetteRects`, `drawBacking`), tessellation constants (`SHEET_LIFT`, `TRANSMISSION_GAIN`, `FLAT_SEGMENTS`), the cloth integrator, the state machine class, ~20 `*OptionsSchema` internals, and **36 individual behavior / deformer / layout functions** the registries already reach.

`getBehavior('peel')` returns exactly what the `peel` export did. `listLayouts()` enumerates what the twelve named exports were. **Nothing left the library — it left the front door.**

## What stayed, and why

The four components, the schema and its types, the registries plus their three `register*` hooks, presets and the `.paper` format, the export helpers, lighting-as-data, interaction states, accessibility.

Three things that *look* internal stay, each with reasoning written at the export site:

| | |
|---|---|
| **parity harness** | the only gate on the invariant the contribution ladder rests on — a contributor's deformer needs it, and apps consume the library through its public API only |
| **tessellation arithmetic** | `registerDeformer` is public, so a third-party deformer must answer the segment-count question the same way the built-in seven do |
| **`wrapLines`** | a caller measuring type before laying out a sheet has to get the same answer the painter will |

`PaperField.tsx` also stops re-exporting field internals it was forwarding by habit — a re-export is how something becomes public by accident. Two test files now import those from their own modules, where they always lived.

## Why now

Nobody has built on the old surface yet, so this costs no one anything today. The identical change after launch is a migration charged to real users for no benefit to them. That timing *is* the argument.

## Verification

`lint`, `knip`, `typecheck`, **707 tests**, `build`, `publint`, `are-the-types-wrong` — plus all three browser gates: **parity 37/37**, **drive**, **share 10/10**.

Ships as **0.4.0** (minor = breaking, pre-1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)