### PR TITLE
docs: route conduct reports to noor@nawwara.studio

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the maintainer at **nawaracontact@gmail.com**. All complaints will
+reported to the maintainer at **noor@nawwara.studio**. All complaints will
 be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
The Contributor Covenant's enforcement section is the only line in it that creates real work, so it should point somewhere you actually read — not the address that happened to be in the commit metadata.

This is now the only email address in the tracked tree. `SECURITY.md` deliberately routes to GitHub private advisories instead of an inbox, so vulnerability reports and conduct reports land in different places on purpose: one needs to stay private and structured, the other needs a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)