### PR TITLE
feat(site): serve the demo from paperlab.nawwara.studio

### DIFF
--- a/.changeset/olive-doors-repeat.md
+++ b/.changeset/olive-doors-repeat.md
@@ -1,0 +1,12 @@
+---
+'paperlab': patch
+---
+
+Point the README and `homepage` at paperlab.nawwara.studio.
+
+The demo, editor, reference and every image in the npm README resolved through
+a URL containing the GitHub account name — `nourmtir0722.github.io` for links,
+`raw.githubusercontent.com/NourMtir0722` for images. A published README is
+frozen at its version forever, so renaming the account would have left every
+release already on npm pointing at a dead demo and showing broken images. The
+custom domain outlives the username.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
         The fastest possible report. Sculpt it in the editor, hit **Share**, and
         paste the link — it carries the whole config, so it reproduces exactly.
         A `.paper` JSON blob or the `<Paper …>` props work too.
-      placeholder: https://nourmtir0722.github.io/Paperlab/editor/?p=...
+      placeholder: https://paperlab.nawwara.studio/editor/?p=...
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/NourMtir0722/Paperlab/security/advisories/new
     about: Report privately instead — please do not open a public issue.
   - name: Try it first
-    url: https://nourmtir0722.github.io/Paperlab/editor/
+    url: https://paperlab.nawwara.studio/editor/
     about: The editor reproduces most things faster than a description does, and Share gives you a link that carries the whole paper.
   - name: The API reference
-    url: https://nourmtir0722.github.io/Paperlab/docs/
+    url: https://paperlab.nawwara.studio/docs/
     about: Every behavior, deformer, layout, stock and surface, rendering live.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,7 +8,10 @@ name: Deploy site
 # No secrets, no third-party account: the OIDC token below is issued by
 # GitHub to this workflow.
 #
-# Live at https://nourmtir0722.github.io/Paperlab/.
+# Live at https://paperlab.nawwara.studio/ — a custom domain, so the URL
+# survives a GitHub username change. The CNAME file below is what keeps it:
+# this deploys via Actions rather than from a branch, and without a CNAME in
+# the artifact each deploy clears the custom domain and takes the site down.
 #
 # The `has_pages` guard below is deliberate. Pages must be enabled on the
 # repository (Settings -> Pages -> Source: "GitHub Actions") and the repository
@@ -16,8 +19,6 @@ name: Deploy site
 # guard skips the deploy instead of failing it, and `workflow_dispatch` is the
 # escape hatch to publish once Pages has been switched on -- this workflow
 # triggers on push, so enabling Pages alone does not build the site.
-#
-# On a custom domain (paperlab.dev), set BASE to '/' and add the CNAME step.
 
 on:
   push:
@@ -34,8 +35,9 @@ permissions:
   id-token: write
 
 env:
-  # Project-pages subpath. Change to '/' when a custom domain is attached.
-  BASE: /Paperlab/
+  # Site root. On the custom domain the site is the apex, not a subpath.
+  BASE: /
+  DOMAIN: paperlab.nawwara.studio
 
 jobs:
   build:
@@ -89,6 +91,12 @@ jobs:
           # Pages serves 404.html for unknown paths; point it at the
           # playground so a stale shared link still lands on something.
           cp site/index.html site/404.html
+          # The README on npm cannot resolve repo-relative paths, so its
+          # images point here. Serving them off the domain rather than
+          # raw.githubusercontent keeps them alive across a username change.
+          cp -r docs/media site/media
+          # Pages reads the custom domain from this file on every deploy.
+          echo "$DOMAIN" > site/CNAME
           # .nojekyll keeps Pages from eating asset dirs that start with _.
           touch site/.nojekyll
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Paperlab renders physical, realistic paper as a React component. Content is a texture on a mesh that genuinely bends — text and imagery curl with perfect continuity. This file is the dense reference for agents integrating Paperlab into a project or contributing to this repo.
 
-> Reading as a human rather than as an agent? The [reference](https://nourmtir0722.github.io/Paperlab/docs/) is the same catalogue with everything rendering live.
+> Reading as a human rather than as an agent? The [reference](https://paperlab.nawwara.studio/docs/) is the same catalogue with everything rendering live.
 
 ## Integrating Paperlab into a project
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions climb a ladder — start wherever you're comfortable. Merged presets and behaviors ship in the editor's library with attribution: credit is the currency here.
 
-**Before the ladder: you don't need it.** A paper is a `.paper` JSON object, so you can make one in the [editor](https://nourmtir0722.github.io/Paperlab/editor/), hit **Share**, and send the link to anyone — they open it, get an editable copy, and drop it in their project with `<Paper preset={json} />`. No fork, no PR, no waiting on a review. The ladder below is for when you want your work to ship *inside* the library so everyone gets it by name.
+**Before the ladder: you don't need it.** A paper is a `.paper` JSON object, so you can make one in the [editor](https://paperlab.nawwara.studio/editor/), hit **Share**, and send the link to anyone — they open it, get an editable copy, and drop it in their project with `<Paper preset={json} />`. No fork, no PR, no waiting on a review. The ladder below is for when you want your work to ship *inside* the library so everyone gets it by name.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A hero image that peels, a receipt that unrolls, a letter that folds, a poster rippling in wind, a gallery ring of prints. A sheet is real 3D geometry, not a CSS trick and not a video — content is a texture on a mesh that genuinely bends, so text and imagery curl with perfect continuity.
 
-**[Try it →](https://nourmtir0722.github.io/Paperlab/)**  ·  [the editor](https://nourmtir0722.github.io/Paperlab/editor/) (desktop)  ·  [the reference](https://nourmtir0722.github.io/Paperlab/docs/)  ·  [for coding agents](AGENTS.md)
+**[Try it →](https://paperlab.nawwara.studio/)**  ·  [the editor](https://paperlab.nawwara.studio/editor/) (desktop)  ·  [the reference](https://paperlab.nawwara.studio/docs/)  ·  [for coding agents](AGENTS.md)
 
 | | |
 |---|---|
@@ -154,7 +154,7 @@ The zod schema in `config/schema.ts` is the single source of truth: it validates
 
 A paper is data — a `.paper` JSON object validated by a zod schema — so it travels without asking anyone's permission. **You do not need to fork this repo to share one.**
 
-**Sending one.** Sculpt a paper in the [editor](https://nourmtir0722.github.io/Paperlab/editor/) and hit **Share**: you get a link with the whole paper packed into it. Anyone who opens that link lands in their own editor with your paper loaded and *editable* — a fork, not a read-only view. (Uploaded images are too big for a URL; use the ⬇ download and send the `.paper` file instead.)
+**Sending one.** Sculpt a paper in the [editor](https://paperlab.nawwara.studio/editor/) and hit **Share**: you get a link with the whole paper packed into it. Anyone who opens that link lands in their own editor with your paper loaded and *editable* — a fork, not a read-only view. (Uploaded images are too big for a URL; use the ⬇ download and send the `.paper` file instead.)
 
 **Receiving one.** Open the link, or drag a `.paper` file onto the preset panel. Either way it lands in your library next to the built-ins.
 
@@ -181,9 +181,9 @@ That's the whole loop: **make → send → remix → ship.** If you'd rather you
 
 Three surfaces ship alongside the library, all built on its public API only.
 
-**[The playground](https://nourmtir0722.github.io/Paperlab/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
+**[The playground](https://paperlab.nawwara.studio/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
 
-**[The editor](https://nourmtir0722.github.io/Paperlab/editor/)** — a three-rail canvas tool: presets on the left, sculpt on canvas, inspector on the right, transport at the bottom (space = play/pause), undo and redo on ⌘Z.
+**[The editor](https://paperlab.nawwara.studio/editor/)** — a three-rail canvas tool: presets on the left, sculpt on canvas, inspector on the right, transport at the bottom (space = play/pause), undo and redo on ⌘Z.
 
 ![The Paperlab editor in paper mode, showing a thermal receipt on the canvas with the inspector open](docs/media/editor.jpg)
 
@@ -193,7 +193,7 @@ The inspector is generated from the zod schema, so it can never drift from the A
 
 Field mode composes galleries against the same panel — swap the layout, watch fourteen papers rearrange in one draw call. **Export code** ends the session in your codebase, and **Copy for AI** ends it in a coding agent's. It wants a real screen: under about 900px it says so and points you at the playground.
 
-**[The reference](https://nourmtir0722.github.io/Paperlab/docs/)** — the whole catalogue with every behavior, deformer, layout, stock and surface rendering live. The catalogue is generated from the registries, so it cannot advertise something the library doesn't have.
+**[The reference](https://paperlab.nawwara.studio/docs/)** — the whole catalogue with every behavior, deformer, layout, stock and surface rendering live. The catalogue is generated from the registries, so it cannot advertise something the library doesn't have.
 
 ## Development
 

--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -6,18 +6,19 @@
     <title>Paperlab — reference</title>
     <meta name="description" content="Every preset, behavior, stock and layout Paperlab ships, rendering live, with the code for each." />
 
+    <meta property="og:url" content="https://paperlab.nawwara.studio/docs/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Paperlab" />
     <meta property="og:title" content="Paperlab — reference" />
     <meta property="og:description" content="Every preset, behavior, stock and layout Paperlab ships, rendering live, with the code for each." />
-    <meta property="og:image" content="https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/og.png" />
+    <meta property="og:image" content="https://paperlab.nawwara.studio/media/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Paperlab — reference" />
     <meta name="twitter:description" content="Every preset, behavior, stock and layout Paperlab ships, rendering live, with the code for each." />
-    <meta name="twitter:image" content="https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/og.png" />
+    <meta name="twitter:image" content="https://paperlab.nawwara.studio/media/og.png" />
 
     <meta name="theme-color" content="#08090a" />
     <style>

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -8,21 +8,22 @@
 
     <!--
       A shared link with no card is a link nobody clicks. og:image has to be
-      an absolute URL, and the raw GitHub path stays valid wherever the site
-      itself ends up hosted.
+      an absolute URL; it points at the site's own domain rather than a raw
+      GitHub path, which would carry the account name and die on a rename.
     -->
+    <meta property="og:url" content="https://paperlab.nawwara.studio/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Paperlab" />
     <meta property="og:title" content="Paperlab — write a room" />
     <meta property="og:description" content="Type something. Walk through it. Real 3D paper as a React component." />
-    <meta property="og:image" content="https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/og.png" />
+    <meta property="og:image" content="https://paperlab.nawwara.studio/media/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Paperlab — write a room" />
     <meta name="twitter:description" content="Type something. Walk through it. Real 3D paper as a React component." />
-    <meta name="twitter:image" content="https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/og.png" />
+    <meta name="twitter:image" content="https://paperlab.nawwara.studio/media/og.png" />
 
     <meta name="theme-color" content="#0b0b0b" />
     <style>

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -8,12 +8,12 @@
 
 A hero image that peels, a receipt that unrolls, a letter that folds, a poster rippling in wind, a gallery ring of prints. A sheet is real 3D geometry, not a CSS trick and not a video — content is a texture on a mesh that genuinely bends, so text and imagery curl with perfect continuity.
 
-**[Try it →](https://nourmtir0722.github.io/Paperlab/)**  ·  [the editor](https://nourmtir0722.github.io/Paperlab/editor/) (desktop)  ·  [the reference](https://nourmtir0722.github.io/Paperlab/docs/)  ·  [for coding agents](https://github.com/NourMtir0722/Paperlab/blob/main/AGENTS.md)
+**[Try it →](https://paperlab.nawwara.studio/)**  ·  [the editor](https://paperlab.nawwara.studio/editor/) (desktop)  ·  [the reference](https://paperlab.nawwara.studio/docs/)  ·  [for coding agents](https://github.com/NourMtir0722/Paperlab/blob/main/AGENTS.md)
 
 | | |
 |---|---|
-| ![A thermal receipt unrolling from a paper roll](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/receipt-unroll.gif) | ![A gloss card with its corner peeling up off the page](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/hero-peel.gif) |
-| ![A letter folding itself into thirds](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/letter-fold.gif) | ![A page turning on its spine](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/page-flip.gif) |
+| ![A thermal receipt unrolling from a paper roll](https://paperlab.nawwara.studio/media/receipt-unroll.gif) | ![A gloss card with its corner peeling up off the page](https://paperlab.nawwara.studio/media/hero-peel.gif) |
+| ![A letter folding itself into thirds](https://paperlab.nawwara.studio/media/letter-fold.gif) | ![A page turning on its spine](https://paperlab.nawwara.studio/media/page-flip.gif) |
 
 Every frame above is real geometry — no video, no sprite sheet.
 
@@ -94,25 +94,25 @@ Underneath them are seven **deformers** — `roll`, `curl`, `bend`, `fold`, `wav
 
 ### Stocks — 7
 
-![The same letter on all seven paper stocks, side by side](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/stocks.jpg)
+![The same letter on all seven paper stocks, side by side](https://paperlab.nawwara.studio/media/stocks.jpg)
 
 One sheet of words, seven papers. Stock is not a colour swap: thermal takes on banding, newsprint takes grain, vellum goes translucent and lets the light through it. On top of stock sit composable surface effects — grain, torn deckle edges, crease lines, perforation, aging — as shader chunks. Alpha-affecting effects use `alphaTest` rather than blending, so shadows stay correct.
 
 ### Layouts — 12
 
-![All twelve field layouts rendered side by side](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/layouts.jpg)
+![All twelve field layouts rendered side by side](https://paperlab.nawwara.studio/media/layouts.jpg)
 
 Every layout names somewhere paper actually sits: `book` (pages splayed from a spine — `split: 0` makes it a swatch deck), `accordion` (one continuous concertina strip), `fan` (a hand of cards), `spread` (a stack slid sideways), `pile` (a heap on a desk), `rack` (prints stood in a row, leaning back), `wall` (a pinned studio wall), `spill` (a dropped stack mid-air), `colonnade` (banners along a walk, for stage mode), `ring`, `sheet`, and `sweep` — a specimen chart of one sheet at ten stages of the same curl.
 
 Each pose also carries a **bias**: how strongly that one sheet takes the deformation. So the top of a pile curls while the sheets pressed underneath lie flat — in the same draw call. A whole field is **one instanced draw call** with the deformers running on the GPU, and the camera frames itself from the layout's own poses, so a wide `wall` and a deep `ring` both land without hand-tuning.
 
-![Twelve cards standing in a ring, each with its corner peeling, rotating slowly](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/field-ring.gif)
+![Twelve cards standing in a ring, each with its corner peeling, rotating slowly](https://paperlab.nawwara.studio/media/field-ring.gif)
 
 Twelve sheets, twelve peeled corners, **one draw call** — the deformers run on the GPU and the text curls with the mesh.
 
 ### Lighting — 8 rigs
 
-![The same letter under all eight lighting rigs](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/lighting.jpg)
+![The same letter under all eight lighting rigs](https://paperlab.nawwara.studio/media/lighting.jpg)
 
 A rig is the starting point, not the ceiling. `light={{ exposure, film, key, color, direction, height, ambient, studio, haze }}` moves the lamp in the terms a person would say it in — degrees around the room, degrees above the horizon — and **studio** is the room itself as an environment map, which is what gives paper directional fill and something for its sheen to reflect. `window` and `leaves` carry a gobo; `lightbox` puts the source behind the sheet and lets you read it through the paper.
 
@@ -120,7 +120,7 @@ Overrides serialize *as* overrides, so a shared scene carries the two sliders yo
 
 ### Stage — paper as architecture
 
-![Printed banners hung down both sides of a colonnade, lit from an opening at the far end](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/stage-nave.gif)
+![Printed banners hung down both sides of a colonnade, lit from an opening at the far end](https://paperlab.nawwara.studio/media/stage-nave.gif)
 
 Banners hung the height of a room along a walk you travel, with light coming through the paper from an opening at the far end. `<PaperStage text="…" />` builds the whole space out of a sentence, and binding `progress` to scroll makes the page scroll the walk.
 
@@ -128,13 +128,13 @@ The room is real — a ceiling, poured floor slabs, columns with base plates, an
 
 **Six rooms ship**, and they are not variations on a theme — the walk changes shape, the paper changes proportion, the light changes where it comes from:
 
-![The six stage presets — nave, procession, cloister, threshold, ribbon and archive](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/stages.jpg)
+![The six stage presets — nave, procession, cloister, threshold, ribbon and archive](https://paperlab.nawwara.studio/media/stages.jpg)
 
 Every one of those is built from the same two things: sheets of paper, and words printed on them. No imagery, no textures from anywhere else.
 
 **Four camera shots** frame any of them, each reading the same walk as the arrangement and the light, so they cannot drift apart:
 
-![The four stage camera shots — follow, lead, low and wide](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/camera.jpg)
+![The four stage camera shots — follow, lead, low and wide](https://paperlab.nawwara.studio/media/camera.jpg)
 
 And it is navigable rather than a video. It drifts on its own until you touch it, then drag it (with inertia), wheel it, step banner to banner with the arrow keys, or click the paper you want to stand in front of. The stops come from the layout, so a step lands *on* a banner. `motion={{ capture: false }}` for a stage inside a scrolling page, so it never eats a reader's scroll. Quality adapts to the machine on its own across four tiers.
 
@@ -154,7 +154,7 @@ The zod schema in `config/schema.ts` is the single source of truth: it validates
 
 A paper is data — a `.paper` JSON object validated by a zod schema — so it travels without asking anyone's permission. **You do not need to fork this repo to share one.**
 
-**Sending one.** Sculpt a paper in the [editor](https://nourmtir0722.github.io/Paperlab/editor/) and hit **Share**: you get a link with the whole paper packed into it. Anyone who opens that link lands in their own editor with your paper loaded and *editable* — a fork, not a read-only view. (Uploaded images are too big for a URL; use the ⬇ download and send the `.paper` file instead.)
+**Sending one.** Sculpt a paper in the [editor](https://paperlab.nawwara.studio/editor/) and hit **Share**: you get a link with the whole paper packed into it. Anyone who opens that link lands in their own editor with your paper loaded and *editable* — a fork, not a read-only view. (Uploaded images are too big for a URL; use the ⬇ download and send the `.paper` file instead.)
 
 **Receiving one.** Open the link, or drag a `.paper` file onto the preset panel. Either way it lands in your library next to the built-ins.
 
@@ -181,19 +181,19 @@ That's the whole loop: **make → send → remix → ship.** If you'd rather you
 
 Three surfaces ship alongside the library, all built on its public API only.
 
-**[The playground](https://nourmtir0722.github.io/Paperlab/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
+**[The playground](https://paperlab.nawwara.studio/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
 
-**[The editor](https://nourmtir0722.github.io/Paperlab/editor/)** — a three-rail canvas tool: presets on the left, sculpt on canvas, inspector on the right, transport at the bottom (space = play/pause), undo and redo on ⌘Z.
+**[The editor](https://paperlab.nawwara.studio/editor/)** — a three-rail canvas tool: presets on the left, sculpt on canvas, inspector on the right, transport at the bottom (space = play/pause), undo and redo on ⌘Z.
 
-![The Paperlab editor in paper mode, showing a thermal receipt on the canvas with the inspector open](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/editor.jpg)
+![The Paperlab editor in paper mode, showing a thermal receipt on the canvas with the inspector open](https://paperlab.nawwara.studio/media/editor.jpg)
 
 The inspector is generated from the zod schema, so it can never drift from the API. Each behavior nominates the two or three params that *are* it — `unroll` opens on progress and tightness, and folds sheet, stock, content, surface, physics and scene away behind their own headings. Labels drag to scrub: full range in ~300px, shift for a 4× finer pass, click the readout to type an exact value.
 
-![The editor in field mode, fourteen cards arranged in a ring with the layout panel open](https://raw.githubusercontent.com/NourMtir0722/Paperlab/main/docs/media/editor-field.jpg)
+![The editor in field mode, fourteen cards arranged in a ring with the layout panel open](https://paperlab.nawwara.studio/media/editor-field.jpg)
 
 Field mode composes galleries against the same panel — swap the layout, watch fourteen papers rearrange in one draw call. **Export code** ends the session in your codebase, and **Copy for AI** ends it in a coding agent's. It wants a real screen: under about 900px it says so and points you at the playground.
 
-**[The reference](https://nourmtir0722.github.io/Paperlab/docs/)** — the whole catalogue with every behavior, deformer, layout, stock and surface rendering live. The catalogue is generated from the registries, so it cannot advertise something the library doesn't have.
+**[The reference](https://paperlab.nawwara.studio/docs/)** — the whole catalogue with every behavior, deformer, layout, stock and surface rendering live. The catalogue is generated from the registries, so it cannot advertise something the library doesn't have.
 
 ## Development
 

--- a/packages/paperlab/package.json
+++ b/packages/paperlab/package.json
@@ -72,7 +72,7 @@
     "vitest": "^4.1.11"
   },
   "author": "Noor Mtir",
-  "homepage": "https://github.com/NourMtir0722/Paperlab#readme",
+  "homepage": "https://paperlab.nawwara.studio",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/NourMtir0722/Paperlab.git",

--- a/tools/sync-readme.mjs
+++ b/tools/sync-readme.mjs
@@ -16,14 +16,22 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const RAW = 'https://raw.githubusercontent.com/NourMtir0722/Paperlab/main'
+// Images resolve against the custom domain rather than raw.githubusercontent.
+// A published README is frozen at its version forever, and a raw URL carries
+// the GitHub username in it — so renaming the account would break every image
+// on every release already sitting on npm. The domain outlives the username.
+// The workflow copies docs/media to /media on the site to make these resolve.
+const MEDIA = 'https://paperlab.nawwara.studio/media'
 const BLOB = 'https://github.com/NourMtir0722/Paperlab/blob/main'
 
 const source = readFileSync(resolve(root, 'README.md'), 'utf8')
 
 const absolute = source
-  // Images resolve against raw.githubusercontent; anything else against blob.
-  .replace(/!\[([^\]]*)\]\((?!https?:)([^)]+)\)/g, (_, alt, path) => `![${alt}](${RAW}/${path})`)
+  // Images resolve against the site's /media; anything else against blob.
+  .replace(
+    /!\[([^\]]*)\]\((?!https?:)([^)]+)\)/g,
+    (_, alt, path) => `![${alt}](${MEDIA}/${path.replace(/^docs\/media\//, '')})`,
+  )
   .replace(/(?<!!)\[([^\]]+)\]\((?!https?:|#)([^)]+)\)/g, (_, text, path) => `[${text}](${BLOB}/${path})`)
 
 const out = resolve(root, 'packages/paperlab/README.md')


### PR DESCRIPTION
The site's URL contained the GitHub account name, and the account is about to be renamed. GitHub Pages is excluded from rename redirects, so every link into the demo would have died — including the ones frozen into the READMEs already published for 0.3.0 and 0.4.0, which can never be edited.

A custom domain outlives the username. DNS and the GitHub Pages custom domain are already configured and verified; this is the repo half.

## What changed

- `BASE` drops from `/Paperlab/` to `/` — the site is the apex now, not a subpath. **This is the urgent one:** the domain is already serving, so the live demo is currently white-screening on `/Paperlab/assets/… → 404` until this merges.
- The assemble step writes `CNAME` into the artifact. Load-bearing: this deploys from Actions rather than a branch, so without that file each deploy clears the custom domain and takes the site down.
- `docs/media` ships to `/media`, so the npm README's images resolve off the domain instead of `raw.githubusercontent.com/NourMtir0722/…`, which carries the username too.
- `og:image` follows; `og:url` gets set now that there's a canonical URL.
- `homepage` in package.json points at the demo rather than the README anchor.
- Changeset for a patch release, so npm carries username-free links before the rename.

## Verified

- `pnpm lint` and `pnpm test` pass
- playground builds with `PAPERLAB_BASE=/` and emits `/assets/…`, not `/Paperlab/assets/…`
- regenerated npm README has 0 remaining `raw.githubusercontent` references
- `paperlab.nawwara.studio` resolves to the GitHub Pages IPs (`185.199.108-111.153`), not Cloudflare's — the grey-cloud DNS-only record is correct, and HTTPS already returns 200

Repo links (`repository`, `bugs`, blob links in the npm README) deliberately stay on `github.com` — those must point at the repo, and GitHub does redirect those on rename.