### PR TITLE
feat(site): route the root by device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,10 @@ jobs:
       # was the one harness in the repo nothing ran.
       - name: Share loop gate
         run: pnpm test:share
+
+      # The site root decides, in a script inside an HTML file, which app
+      # every visitor sees — the editor has no mobile layout, so guessing
+      # wrong strands a phone on a three-rail desktop tool. Nothing else in
+      # the pipeline type-checks or renders that file, so check it directly.
+      - name: Root routing gate
+        run: pnpm test:route

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,9 @@
 name: Deploy site
 
-# The playground is the demo — a 3D library nobody can try is a screenshot.
-# Publishes the playground at the site root, the editor at /editor, and the
-# reference at /docs.
+# A 3D library nobody can try is a screenshot, so the site is the demo.
+# The root is a signpost that picks by device — the editor is a three-rail
+# desktop tool with no mobile layout, the playground was built for a phone —
+# and the apps sit at /editor, /playground and /docs behind it.
 #
 # One-time setup: repo Settings → Pages → Source: "GitHub Actions".
 # No secrets, no third-party account: the OIDC token below is issued by
@@ -65,10 +66,10 @@ jobs:
       - name: Build the library
         run: pnpm --filter paperlab build
 
-      - name: Build the playground (site root)
+      - name: Build the playground (/playground)
         run: pnpm --filter @paperlab/playground exec vite build
         env:
-          PAPERLAB_BASE: ${{ env.BASE }}
+          PAPERLAB_BASE: ${{ env.BASE }}playground/
 
       - name: Build the editor (/editor)
         run: pnpm --filter @paperlab/editor exec vite build
@@ -83,13 +84,16 @@ jobs:
       - name: Assemble the site
         run: |
           mkdir -p site
-          cp -r apps/playground/dist/* site/
+          # The root picks a destination by device; the apps sit behind it.
+          cp tools/site-root.html site/index.html
+          mkdir -p site/playground
+          cp -r apps/playground/dist/* site/playground/
           mkdir -p site/editor
           cp -r apps/editor/dist/* site/editor/
           mkdir -p site/docs
           cp -r apps/docs/dist/* site/docs/
-          # Pages serves 404.html for unknown paths; point it at the
-          # playground so a stale shared link still lands on something.
+          # Pages serves 404.html for unknown paths; point it at the root
+          # signpost so a stale shared link still lands on something.
           cp site/index.html site/404.html
           # The README on npm cannot resolve repo-relative paths, so its
           # images point here. Serving them off the domain rather than

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ That's the whole loop: **make → send → remix → ship.** If you'd rather you
 
 Three surfaces ship alongside the library, all built on its public API only.
 
-**[The playground](https://paperlab.nawwara.studio/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
+**[The playground](https://paperlab.nawwara.studio/playground/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
 
 **[The editor](https://paperlab.nawwara.studio/editor/)** — a three-rail canvas tool: presets on the left, sculpt on canvas, inspector on the right, transport at the bottom (space = play/pause), undo and redo on ⌘Z.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "perf:field": "node tools/field-perf.mjs",
     "media": "node tools/media.mjs",
     "test:share": "node tools/share-loop-check.mjs",
+    "test:route": "node tools/route-check.mjs",
     "test:drive": "node tools/stage-drive-check.mjs",
     "shot:light": "node tools/catalogue-shot.mjs --vary=lighting --all",
     "shot:catalogue": "node tools/catalogue-shot.mjs",

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -181,7 +181,7 @@ That's the whole loop: **make → send → remix → ship.** If you'd rather you
 
 Three surfaces ship alongside the library, all built on its public API only.
 
-**[The playground](https://paperlab.nawwara.studio/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
+**[The playground](https://paperlab.nawwara.studio/playground/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
 
 **[The editor](https://paperlab.nawwara.studio/editor/)** — a three-rail canvas tool: presets on the left, sculpt on canvas, inspector on the right, transport at the bottom (space = play/pause), undo and redo on ⌘Z.
 

--- a/tools/route-check.mjs
+++ b/tools/route-check.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Checks the site root's device routing.
+ *
+ * The root is the URL everyone shares, and a script inside an HTML file is
+ * the one bit of the site nothing else type-checks or renders — a typo there
+ * sends every launch visitor to the wrong app, silently. So pull the script
+ * out of the page and run the real thing against fake locations.
+ *
+ * Runs in CI as `pnpm test:route`.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const html = readFileSync(resolve(root, 'tools/site-root.html'), 'utf8')
+
+const script = html.match(/<script>([\s\S]*?)<\/script>/)
+if (!script) {
+  console.error('site-root.html has no redirect script — the root would strand every visitor')
+  process.exit(1)
+}
+
+/** Runs the page's own script against a fake window and reports where it sent us. */
+function route({ search = '', hash = '', width = 1440, pointer = 'fine' }) {
+  let destination = null
+  const window = {
+    location: { search, hash, replace: (url) => (destination = url) },
+    matchMedia: (query) => ({
+      matches: query.includes('min-width: 1024px')
+        ? width >= 1024
+        : query.includes('pointer: fine')
+          ? pointer === 'fine'
+          : false,
+    }),
+  }
+  new Function('window', script[1])(window)
+  return destination
+}
+
+const SCENE = '?s=eyJwIjoibmF2ZSJ9'
+
+const cases = [
+  // The whole point: the editor has no mobile layout, the playground does.
+  ['desktop lands in the editor', { width: 1440, pointer: 'fine' }, '/editor/'],
+  ['phone lands in the playground', { width: 390, pointer: 'coarse' }, '/playground/'],
+  ['touch tablet is not a desktop', { width: 1024, pointer: 'coarse' }, '/playground/'],
+  ['a narrow window is not either', { width: 900, pointer: 'fine' }, '/playground/'],
+
+  // A shared link named its destination on purpose; the guess must not win.
+  ['a shared scene opens on desktop', { search: SCENE, width: 1440 }, `/playground/${SCENE}`],
+  [
+    'a shared scene opens on a phone',
+    { search: SCENE, width: 390, pointer: 'coarse' },
+    `/playground/${SCENE}`,
+  ],
+  ['a shared sculpt opens in the editor', { search: '?p=abc', width: 1440 }, '/editor/?p=abc'],
+  ['the hash survives the hop', { search: '?s=xyz', hash: '#top', width: 1440 }, '/playground/?s=xyz#top'],
+
+  // A campaign tag is not a share link, so the device still decides.
+  ['utm does not look like a share', { search: '?utm_source=x', width: 1440 }, '/editor/'],
+  [
+    'utm on a phone still routes by device',
+    { search: '?utm_source=x', width: 390, pointer: 'coarse' },
+    '/playground/',
+  ],
+]
+
+let failed = 0
+for (const [name, input, expected] of cases) {
+  const got = route(input)
+  const ok = got === expected
+  if (!ok) failed++
+  console.log(
+    `${ok ? '  ok  ' : '  FAIL'} ${name.padEnd(36)} → ${got}${ok ? '' : `   (expected ${expected})`}`,
+  )
+}
+
+console.log(failed ? `\n${failed} of ${cases.length} routes wrong` : `\nall ${cases.length} routes correct`)
+process.exit(failed ? 1 : 0)

--- a/tools/site-root.html
+++ b/tools/site-root.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Paperlab — physical paper as a React component</title>
+    <meta name="description" content="Real 3D paper that peels, unrolls, folds and hangs. A React component, not a CSS trick and not a video." />
+
+    <!--
+      The site root is a signpost, not a page. The editor is a three-rail
+      desktop tool with no mobile layout, and the playground is built for a
+      phone — so sending everyone to the same one strands half of them. This
+      picks by device instead, and the crawler that never runs the script
+      still reads the card below.
+
+      Assembled into the site by .github/workflows/pages.yml. The apps
+      themselves live at /editor/, /playground/ and /docs/.
+    -->
+    <meta property="og:url" content="https://paperlab.nawwara.studio/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Paperlab" />
+    <meta property="og:title" content="Paperlab — physical paper as a React component" />
+    <meta property="og:description" content="Real 3D paper that peels, unrolls, folds and hangs. A React component, not a CSS trick and not a video." />
+    <meta property="og:image" content="https://paperlab.nawwara.studio/media/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Paperlab — physical paper as a React component" />
+    <meta name="twitter:description" content="Real 3D paper that peels, unrolls, folds and hangs. A React component, not a CSS trick and not a video." />
+    <meta name="twitter:image" content="https://paperlab.nawwara.studio/media/og.png" />
+
+    <meta name="theme-color" content="#0b0b0b" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        min-height: 100%;
+        background: #0b0b0b;
+        color: #f4f2ee;
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+      /* Only ever seen without JS: with it, the redirect fires first. */
+      main {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        padding: 2rem;
+        text-align: center;
+      }
+      h1 {
+        margin: 0;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+      }
+      p {
+        margin: 0;
+        max-width: 32rem;
+        line-height: 1.5;
+        color: #a8a29b;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+      }
+      a {
+        padding: 0.6rem 1.1rem;
+        border: 1px solid #2a2a28;
+        border-radius: 999px;
+        color: #f4f2ee;
+        font-size: 0.9rem;
+        text-decoration: none;
+      }
+      a:hover {
+        border-color: #56544f;
+      }
+    </style>
+    <script>
+      // Runs before paint, so nobody sees the fallback flash past.
+      ;(() => {
+        var search = window.location.search
+        var tail = search + window.location.hash
+        var target = null
+        // The editor needs room and a real cursor. Anything else gets the
+        // playground, which was built for a phone in the first place.
+        var roomy = window.matchMedia('(min-width: 1024px)').matches
+        var precise = window.matchMedia('(pointer: fine)').matches
+
+        // A shared link names its own destination: ?s= is a playground scene,
+        // ?p= is an editor sculpt. Honour that over the device guess —
+        // someone sent this exact thing on purpose.
+        if (/[?&]s=/.test(search)) {
+          target = '/playground/'
+        } else if (/[?&]p=/.test(search)) {
+          target = '/editor/'
+        } else {
+          target = roomy && precise ? '/editor/' : '/playground/'
+          tail = ''
+        }
+
+        // Replace, not assign: back should leave the site, not bounce here.
+        window.location.replace(target + tail)
+      })()
+    </script>
+  </head>
+  <body>
+    <main>
+      <h1>Paperlab</h1>
+      <p>Physical, realistic paper as a React component — real 3D geometry that peels, unrolls, folds and hangs.</p>
+      <nav>
+        <a href="/editor/">The editor <span aria-hidden="true">→</span></a>
+        <a href="/playground/">The playground <span aria-hidden="true">→</span></a>
+        <a href="/docs/">The reference <span aria-hidden="true">→</span></a>
+      </nav>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
You wanted the editor to be the first thing people see. It is now — on a desktop.

## The catch that shaped this

The editor has **no mobile handling at all**: no breakpoints, no pointer check, no "desktop only" notice. `README.md` labels it `(desktop)` and that is the entire mitigation. A launch post is mostly phone traffic, so putting the editor at the root unconditionally would have handed most visitors a three-rail desktop UI with no fallback as their first impression of Paperlab.

So the root is a signpost rather than a page: desktop gets the editor, everything else gets the playground, which was built for a phone.

## What changed

- The playground moves to `/playground/`. The editor (`/editor/`) and reference (`/docs/`) stay where they are.
- The root is [tools/site-root.html](tools/site-root.html) — ~4KB, redirects before paint.
- **A shared link names its own destination, and that beats the device guess.** `?s=` is a playground scene, `?p=` is an editor sculpt. Someone sent that exact thing on purpose. Old `/?s=…` links keep working — the query and hash are carried across the hop.
- The root carries the OG card, so a crawler that never runs the script still sees something worth clicking.
- Without JS the page renders three links instead of a blank screen.
- `404.html` points at the signpost, so unknown paths still land somewhere.

## Verified

- **`pnpm test:route`, new and wired into CI** — extracts the page's own script and runs it against fake locations. 10 cases: desktop, phone, touch tablet, narrow window, shared scene from both device types, shared sculpt, hash preservation, and `?utm=` (which must *not* look like a share link). A script inside an HTML file is the one part of the site nothing else type-checks or renders, and getting it wrong fails silently.
- `pnpm lint`, `pnpm knip`, `pnpm test` all pass
- Playground builds at the new base and emits `/playground/assets/…`
- Assembled the site locally, served it, and confirmed `/`, `/playground/`, `/media/og.png` and `/404.html` all resolve

## Worth deciding separately

The editor still has no mobile fallback. This routes around that rather than fixing it — someone who opens `/editor/` directly on a phone still gets the broken layout. A short "this needs a desktop" notice would close it properly.