### PR TITLE
Content is editable on every sheet, and every save tells the truth

### DIFF
--- a/.changeset/content-is-five-types-not-two.md
+++ b/.changeset/content-is-five-types-not-two.md
@@ -1,0 +1,20 @@
+---
+'paperlab': minor
+---
+
+Publish `contentNames` and `contentSchemaFor`, so content can be edited the way
+everything else already is.
+
+Behaviors, layouts and the stage all hand their editor UI to a caller by
+publishing a zod schema and letting it be walked. Content could not: the union
+was internal, so the only way to build a panel for a `receipt` was to write one
+by hand and keep it in step with the schema — which is exactly what the editor
+did, for two of the five types, until `card`, `receipt` and `blank` each opened
+onto an empty folder.
+
+`contentNames` is read off the union rather than written beside it, because the
+sibling name lists here (`stockNames`, `physicsNames`) are the SOURCE their
+schema is built from and this one is not — a hand-written copy would be free to
+drift the day a sixth content type lands. `contentSchemaFor` answers which
+member carries which discriminator, which is the union's own fact to state
+rather than a walk's to rediscover.

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -5,6 +5,7 @@ import {
   PaperFieldMesh,
   PaperLighting,
   PaperMesh,
+  diffConfig,
   getPreset,
   isBuiltinPreset,
   listPresets,
@@ -32,10 +33,10 @@ import { ViewportGuide } from './chrome/ViewportGuide'
 import { CoachMark, HandleAnchor, coachMarkUsed } from './chrome/CoachMark'
 import { CameraRig, ViewCluster } from './chrome/ViewCluster'
 import { SmallScreen } from './chrome/SmallScreen'
-import { captureThumbnail } from './state/userPresets'
-import { SHARE_PARAM, paperShareUrl, readPaperShare } from './state/paperShare'
+import { captureThumbnail, downloadPreset } from './state/userPresets'
+import { MAX_SHARE_LENGTH, SHARE_PARAM, paperShareUrl, readPaperShare } from './state/paperShare'
 import { DEMO_CARDS } from './state/demoAssets'
-import { UIHost, promptDialog, toast } from './controls/ui'
+import { UIHost, confirmDialog, promptDialog, toast } from './controls/ui'
 import { useEditor, zoneToConfig } from './state/store'
 import { Select } from './controls/Select'
 import { useHistory, useHistoryKeys, useUndoState } from './state/history'
@@ -261,15 +262,26 @@ export function App() {
               // a step that stops the thing from being sent at all.
               const snapshot =
                 editingState || statePreview ? config : (paperRef.current?.snapshot() ?? config)
-              const url = paperShareUrl(window.location.href, snapshot.meta.name, snapshot)
-              if (!url) {
-                toast(
-                  'This paper carries an uploaded image, which is too big for a link. Download the .paper file and send that instead.',
-                  'error',
-                )
+              const attempt = paperShareUrl(window.location.href, snapshot.meta.name, snapshot)
+              if (!attempt.ok) {
+                // The `.paper` file is the answer to both refusals, and it is
+                // offered here rather than described: telling someone whose
+                // share just failed to go and save a preset, find it in the
+                // left panel and download it is three steps and two panels
+                // away from the button they actually pressed.
+                void confirmDialog({
+                  title: 'Too big for a link',
+                  message:
+                    attempt.reason === 'uploaded-image'
+                      ? 'This paper carries an uploaded image. A picture cannot travel in a URL, but the .paper file carries it — download that and send it instead.'
+                      : `This paper needs about ${Math.round(attempt.length / 1000)}KB and a link holds ${Math.round(MAX_SHARE_LENGTH / 1000)}KB. Shorten the text, or download the .paper file and send that instead.`,
+                  confirmLabel: 'Download .paper',
+                }).then((ok) => {
+                  if (ok) downloadPreset(snapshot.meta.name, diffConfig(snapshot))
+                })
                 return
               }
-              void navigator.clipboard.writeText(url)
+              void navigator.clipboard.writeText(attempt.url)
               toast('Link copied — anyone who opens it gets an editable copy', 'success')
             }}
           >

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -37,6 +37,7 @@ import { captureThumbnail, downloadPreset } from './state/userPresets'
 import { MAX_SHARE_LENGTH, SHARE_PARAM, paperShareUrl, readPaperShare } from './state/paperShare'
 import { DEMO_CARDS } from './state/demoAssets'
 import { UIHost, confirmDialog, promptDialog, toast } from './controls/ui'
+import { reportSave } from './chrome/saveReport'
 import { useEditor, zoneToConfig } from './state/store'
 import { Select } from './controls/Select'
 import { useHistory, useHistoryKeys, useUndoState } from './state/history'
@@ -100,18 +101,24 @@ export function App() {
     adopted.current = true
     const share = readPaperShare(window.location.search)
     if (!share) return
-    const error = importSharedPaper(share)
+    const outcome = importSharedPaper(share)
     const url = new URL(window.location.href)
     url.searchParams.delete(SHARE_PARAM)
     window.history.replaceState(null, '', url)
-    if (error) {
-      toast(error, 'error')
+    if (!outcome.ok) {
+      toast(outcome.error, 'error')
       return
     }
     // A link outranks the remembered session: someone who was last in stage
     // mode has to be shown the paper they just opened, not told about it.
     setMode('paper')
-    toast(`Opened "${share.name}" — it's yours to edit now`, 'success')
+    // An opened link that could not be stored is still worth warning about —
+    // it is someone else's paper, and losing it means going back for the URL.
+    if (outcome.storage === 'stored') {
+      toast(`Opened "${outcome.name}" — it's yours to edit now`, 'success')
+    } else {
+      reportSave(outcome)
+    }
   }, [importSharedPaper, setMode])
 
   // Presets are components: the field renders the live edit of its preset.
@@ -242,9 +249,7 @@ export function App() {
                 // base and lose the machine. The preset is the store's base.
                 const snapshot =
                   editingState || statePreview ? config : (paperRef.current?.snapshot() ?? config)
-                const error = savePreset(name, snapshot, captureThumbnail())
-                if (error) toast(error, 'error')
-                else toast(`Saved "${name}"`, 'success')
+                reportSave(savePreset(name, snapshot, captureThumbnail()))
               })()
             }}
           >

--- a/apps/editor/src/chrome/saveReport.ts
+++ b/apps/editor/src/chrome/saveReport.ts
@@ -1,0 +1,42 @@
+import { confirmDialog, toast } from '../controls/ui'
+import { downloadPreset } from '../state/userPresets'
+import type { SaveOutcome } from '../state/store'
+
+/**
+ * Say what actually happened to a save.
+ *
+ * Every way into the preset store — Save preset, dropping a `.paper` file,
+ * opening someone's link — ends here, so there is one account of a save and
+ * not three that can disagree.
+ *
+ * The case this exists for is `session-only`. A preset that reaches the
+ * registry but not localStorage is live, editable and completely convincing
+ * until the tab closes, and it used to report itself as a plain "Saved".
+ * Storage runs out for an ordinary reason now that any sheet can carry an
+ * uploaded image: a data URL is ~100KB and up, and a handful of them clears
+ * the quota. Being told "Saved" and then losing the work is the failure
+ * shape worth spending a dialog on, and the dialog carries the same escape
+ * hatch a refused share does — the `.paper` file, which has no quota.
+ */
+export function reportSave(outcome: SaveOutcome): void {
+  if (!outcome.ok) {
+    toast(outcome.error, 'error')
+    return
+  }
+  const { name, config, storage } = outcome
+  if (storage === 'session-only') {
+    void confirmDialog({
+      title: 'Saved, but not to disk',
+      message: `"${name}" is live and editable, but this browser's storage is full — it will not survive a reload. Download the .paper file to keep it.`,
+      confirmLabel: 'Download .paper',
+    }).then((ok) => {
+      if (ok) downloadPreset(name, config)
+    })
+  } else if (storage === 'thumbnails-dropped') {
+    // Not worth a dialog: nothing was lost but the pictures on the preset
+    // list, and they are regenerated on the next save that fits.
+    toast(`Saved "${name}" — storage is nearly full, so preset thumbnails were dropped`, 'info')
+  } else {
+    toast(`Saved "${name}"`, 'success')
+  }
+}

--- a/apps/editor/src/controls/controls.tsx
+++ b/apps/editor/src/controls/controls.tsx
@@ -229,6 +229,19 @@ function ToggleControl({ control }: { control: Of<'toggle'> }) {
  * Text commits on blur / Enter rather than per keystroke: the canvas rebuilds
  * its content texture on every change, and doing that per character while
  * someone types a paragraph into a banner is what makes the app feel slow.
+ *
+ * That model is right and stays. What was missing was any way to SEE it, and
+ * on the textarea any way to trigger it — Enter is a newline there, so the
+ * only commit was clicking somewhere else in the panel and hoping. Content
+ * text is a textarea (`rows: 4`), which made the app's most-used field the
+ * one with no commit at all.
+ *
+ * So an uncommitted draft now says so twice: the label brightens a step, and
+ * the textarea grows an Apply button. Both appear only while dirty — a
+ * button that is always there, and does nothing most of the time, teaches
+ * nobody when it matters. The one-line input keeps Enter and takes only the
+ * brightened label: the row is `label | input | 44px` with nowhere to put a
+ * button, and Enter is already the answer there.
  */
 function TextControl({ control }: { control: Of<'text'> }) {
   const [draft, setDraft] = useState(control.value)
@@ -239,6 +252,8 @@ function TextControl({ control }: { control: Of<'text'> }) {
     if (draft !== control.value) setDraft(control.value)
   }
 
+  const dirty = draft !== control.value
+
   const commit = () => {
     if (draft !== control.value) {
       committed.current = draft
@@ -246,18 +261,50 @@ function TextControl({ control }: { control: Of<'text'> }) {
     }
   }
 
+  const multiline = Boolean(control.rows && control.rows > 1)
+
   return (
-    <div className={`control-row${control.rows && control.rows > 1 ? ' stacked' : ''}`}>
+    <div className={`control-row${multiline ? ' stacked' : ''}${dirty ? ' dirty' : ''}`}>
       <span className="control-label">{control.label}</span>
-      {control.rows && control.rows > 1 ? (
-        <textarea
-          className="control-text"
-          rows={control.rows}
-          value={draft}
-          aria-label={control.label}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
-        />
+      {multiline ? (
+        <>
+          <textarea
+            className="control-text"
+            rows={control.rows}
+            value={draft}
+            title={control.hint}
+            aria-label={control.label}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              // Enter is a newline in a textarea, so the commit key is the
+              // one every other multi-line editor uses for "send".
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault()
+                commit()
+              }
+              // Abandon the draft and go back to what is on the sheet.
+              if (e.key === 'Escape') setDraft(control.value)
+            }}
+          />
+          {dirty && (
+            <button
+              type="button"
+              className="control-apply"
+              // On mousedown, not click: clicking blurs the textarea first,
+              // which commits, which un-dirties, which unmounts this button
+              // before its own click ever lands. preventDefault keeps the
+              // caret where it was — applying is not leaving.
+              onMouseDown={(e) => {
+                e.preventDefault()
+                commit()
+              }}
+              onClick={commit}
+            >
+              Apply <kbd>⌘↵</kbd>
+            </button>
+          )}
+        </>
       ) : (
         <input
           type="text"
@@ -269,6 +316,7 @@ function TextControl({ control }: { control: Of<'text'> }) {
           onBlur={commit}
           onKeyDown={(e) => {
             if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+            if (e.key === 'Escape') setDraft(control.value)
           }}
         />
       )}

--- a/apps/editor/src/panels/Inspector.tsx
+++ b/apps/editor/src/panels/Inspector.tsx
@@ -1,4 +1,6 @@
 import {
+  contentNames,
+  contentSchemaFor,
   getBehavior,
   getStock,
   lightingNames,
@@ -9,6 +11,7 @@ import {
   stockNames,
   type ClothConfig,
   type ContentConfig,
+  type ContentConfigInput,
   type PaperEdge,
   type PhysicsConfig,
   type StockName,
@@ -17,8 +20,10 @@ import {
 import {
   button,
   folder,
+  note,
   num,
   partitionSignature,
+  schemaControls,
   select,
   text,
   toggle,
@@ -26,6 +31,7 @@ import {
 } from '../controls/controlModel'
 import { Panel } from '../controls/controls'
 import { useEditor } from '../state/store'
+import { formatItems, parseItems } from './receiptItems'
 
 /**
  * Inspector of the selection: a tree of `Control` descriptors rendered by the
@@ -266,31 +272,96 @@ function pickImageAsDataUrl(): Promise<string | null> {
   })
 }
 
+/** What the `src` field shows in place of a 200KB base64 string. */
+const UPLOADED = '(uploaded image)'
+
+/**
+ * The Content folder: which kind of thing prints on the sheet, then that
+ * kind's own fields.
+ *
+ * Everything below the type selector is generated from the variant's zod
+ * schema by the same walk that gives behaviors, layouts and the stage their
+ * panels. Content was the one branch of the config still hand-written, and
+ * it had grown UI for two of the five types — so `card`, `receipt` and
+ * `blank` each opened onto an empty folder, and no sheet could be turned
+ * into another kind at all.
+ *
+ * Four fields stay hand-built, because they are the four the walk cannot
+ * state well. They are placed FIRST, ahead of the generated rest, on a rule
+ * worth keeping as more content types land: the content itself, and then
+ * how it is set.
+ */
 function contentControls(
   content: ContentConfig,
-  patchConfig: (p: { content: ContentConfig }, opts?: { external?: boolean }) => void,
+  patchConfig: (p: { content: ContentConfigInput }, opts?: { external?: boolean }) => void,
 ): Control[] {
-  if (content.type === 'text') {
-    return [
-      text('text', content.text, (v) => patchConfig({ content: { ...content, text: v } }), { rows: 4 }),
-      num('size', content.size, { min: 12, max: 128, step: 1 }, (v) =>
-        patchConfig({ content: { ...content, size: v } }),
-      ),
-    ]
-  }
+  const set = (patch: Record<string, unknown>, opts?: { external?: boolean }) =>
+    patchConfig({ content: { ...content, ...patch } as ContentConfigInput }, opts)
+
+  // The patch is the discriminator and nothing else: a differing `type`
+  // replaces the union wholesale (mergeWithDeletes) rather than merging, and
+  // the parse that follows fills the new variant's defaults — so switching to
+  // `receipt` cannot leave a `src` behind. External, because every row under
+  // this one is about to be a different set and the inspector should remount.
+  const controls: Control[] = [
+    select('type', content.type, [...contentNames], (v) =>
+      patchConfig({ content: { type: v } as ContentConfigInput }, { external: true }),
+    ),
+  ]
+
+  // `back` is a nested discriminated union — what prints on the REVERSE of
+  // the sheet. The walk skips it silently; naming it here says that is meant.
+  const skip = ['type', 'back']
+
   if (content.type === 'image') {
-    return [
-      text('src', content.src.startsWith('data:') ? '(uploaded image)' : content.src, (v) => {
-        if (v === '(uploaded image)') return
-        patchConfig({ content: { ...content, src: v } })
-      }),
+    skip.push('src')
+    controls.push(
+      text(
+        'src',
+        content.src.startsWith('data:') ? UPLOADED : content.src,
+        (v) => {
+          // Editing the mask itself would replace the picture with the words.
+          if (v !== UPLOADED) set({ src: v })
+        },
+        { hint: 'a URL, or upload a file below' },
+      ),
       button('upload image', () => {
         void pickImageAsDataUrl().then((dataUrl) => {
           // external → the inspector remounts and the src field shows the mask.
-          if (dataUrl) patchConfig({ content: { ...content, src: dataUrl } }, { external: true })
+          if (dataUrl) set({ src: dataUrl }, { external: true })
         })
       }),
-    ]
+    )
   }
-  return []
+
+  if (content.type === 'text') {
+    skip.push('text')
+    controls.push(text('text', content.text, (v) => set({ text: v }), { rows: 4 }))
+  }
+
+  if (content.type === 'card') {
+    skip.push('body')
+    controls.push(text('body', content.body, (v) => set({ body: v }), { rows: 3 }))
+  }
+
+  if (content.type === 'receipt') {
+    skip.push('items')
+    controls.push(
+      text('items', formatItems(content.items), (v) => set({ items: parseItems(v) }), { rows: 5 }),
+      // A visible line, not a tooltip: the format is not guessable, and a
+      // hint nobody hovers is a hint nobody reads.
+      note('itemsFormat', 'One item per line — NAME | PRICE'),
+    )
+  }
+
+  controls.push(
+    ...schemaControls(
+      contentSchemaFor(content.type),
+      content as unknown as Record<string, unknown>,
+      (key, value) => set({ [key]: value }),
+      skip,
+    ),
+  )
+
+  return controls
 }

--- a/apps/editor/src/panels/PresetPanel.tsx
+++ b/apps/editor/src/panels/PresetPanel.tsx
@@ -4,6 +4,7 @@ import { useEditor } from '../state/store'
 import { downloadPreset } from '../state/userPresets'
 import { confirmDialog, promptDialog, toast } from '../controls/ui'
 import { Select } from '../controls/Select'
+import { reportSave } from '../chrome/saveReport'
 
 /**
  * The preset library: built-ins (duplicate to fork) and user presets
@@ -27,9 +28,7 @@ export function PresetPanel() {
 
   const importFiles = async (files: FileList | null) => {
     for (const file of files ?? []) {
-      const error = importPreset(await file.text())
-      if (error) toast(error, 'error')
-      else toast(`Imported ${file.name}`, 'success')
+      reportSave(importPreset(await file.text()))
     }
   }
 

--- a/apps/editor/src/panels/receiptItems.test.ts
+++ b/apps/editor/src/panels/receiptItems.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { formatItems, parseItems } from './receiptItems'
+
+describe('receipt items', () => {
+  it('round-trips the shipped default', () => {
+    const items = [
+      { name: 'CURL, TRUE', price: 12 },
+      { name: 'ROLL, TIGHT', price: 8.5 },
+      { name: 'SHEET, ONE', price: 0.99 },
+    ]
+    expect(parseItems(formatItems(items))).toEqual(items)
+  })
+
+  it('formats one item per line', () => {
+    expect(
+      formatItems([
+        { name: 'A', price: 1 },
+        { name: 'B', price: 2 },
+      ]),
+    ).toBe('A | 1\nB | 2')
+  })
+
+  it('is stable under a second round trip', () => {
+    // The control compares the drawn value against the string it last
+    // committed; a format that drifted would read as an external edit and
+    // clobber the draft on every keystroke.
+    const once = formatItems(parseItems('CURL, TRUE | 12'))
+    expect(formatItems(parseItems(once))).toBe(once)
+  })
+
+  it('splits on the last pipe, so a name may contain one', () => {
+    expect(parseItems('A | B | 3')).toEqual([{ name: 'A | B', price: 3 }])
+  })
+
+  it('reads a half-typed line as a name with no price yet', () => {
+    expect(parseItems('CURL, TRUE')).toEqual([{ name: 'CURL, TRUE', price: 0 }])
+  })
+
+  it('tolerates the currency symbols and spaces people actually type', () => {
+    expect(parseItems('THING |  $12.50 ')).toEqual([{ name: 'THING', price: 12.5 }])
+  })
+
+  it('falls back to zero rather than NaN on an unparseable price', () => {
+    // NaN would fail the schema parse and take the render down with it.
+    expect(parseItems('THING | free')).toEqual([{ name: 'THING', price: 0 }])
+  })
+
+  it('drops blank and whitespace-only lines', () => {
+    expect(parseItems('A | 1\n\n   \nB | 2')).toEqual([
+      { name: 'A', price: 1 },
+      { name: 'B', price: 2 },
+    ])
+  })
+
+  it('an empty textarea is an empty receipt, not one blank item', () => {
+    expect(parseItems('')).toEqual([])
+  })
+})

--- a/apps/editor/src/panels/receiptItems.ts
+++ b/apps/editor/src/panels/receiptItems.ts
@@ -1,0 +1,49 @@
+/**
+ * The receipt's line items, as editable text.
+ *
+ * `items` is an array of objects, and the inspector's schema walk does not
+ * do arrays — but a receipt whose purchases cannot be changed is a receipt
+ * PRESET, not a receipt you can edit, and that is most of why the Content
+ * folder felt empty on the app's own default paper.
+ *
+ * One item per line. Name and price split on the LAST pipe, so a name may
+ * contain one.
+ *
+ * It lives in its own module rather than beside the panel that draws it for
+ * one reason: `parse` is the only part of this folder that can be WRONG
+ * about something — a missing separator, a typed currency symbol, a price
+ * that is not a number — and every one of those is a case worth stating in a
+ * test rather than discovering on someone's receipt.
+ */
+export interface ReceiptItem {
+  name: string
+  price: number
+}
+
+/**
+ * Round-trips through {@link parseItems} exactly: `format(parse(format(x)))
+ * === format(x)`. That is what lets the textarea hold a draft without
+ * fighting the value underneath it — the control adopts external edits by
+ * comparing against the string it last committed, and a format that drifted
+ * would look like an external edit on every keystroke.
+ */
+export function formatItems(items: readonly ReceiptItem[]): string {
+  return items.map((item) => `${item.name} | ${item.price}`).join('\n')
+}
+
+export function parseItems(raw: string): ReceiptItem[] {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const split = line.lastIndexOf('|')
+      // No separator is a name with no price yet, not a parse failure — it
+      // is what a half-typed line looks like, and a half-typed line should
+      // not blank the row you were adding it to.
+      if (split === -1) return { name: line, price: 0 }
+      // Currency symbols and stray spaces are what people actually type.
+      const price = Number.parseFloat(line.slice(split + 1).replace(/[^\d.-]/g, ''))
+      return { name: line.slice(0, split).trim(), price: Number.isFinite(price) ? price : 0 }
+    })
+}

--- a/apps/editor/src/state/paperShare.test.ts
+++ b/apps/editor/src/state/paperShare.test.ts
@@ -50,24 +50,77 @@ describe('encoding a paper into a link', () => {
   })
 })
 
+/** The refusal of a share that is expected to fail. */
+function refusal(name: string, config: Parameters<typeof tryEncodePaperShare>[1]) {
+  const attempt = tryEncodePaperShare(name, config)
+  if (attempt.ok) throw new Error('expected a refusal, got a link')
+  return attempt
+}
+
+const upload = (bytes: number) =>
+  paperConfigSchema.parse({
+    ...receipt,
+    content: { type: 'image', src: `data:image/jpeg;base64,${'A'.repeat(bytes)}` },
+  })
+
 describe('refusing what cannot travel', () => {
   it('refuses a paper carrying an uploaded image rather than emitting a broken link', () => {
     // An uploaded image lands in the config as a data URL. A downscaled JPEG
     // is still ~100 KB, which no URL survives — say so instead of truncating.
-    const withUpload = paperConfigSchema.parse({
+    expect(refusal('photo', upload(120_000)).reason).toBe('uploaded-image')
+  })
+
+  it('blames the upload, not the length, so the advice can differ', () => {
+    // The two refusals need different answers — an image can only be sent as
+    // a file, whereas a long paper can be shortened — so a share that fails
+    // because of a picture must not be reported as merely wordy.
+    const long = paperConfigSchema.parse({
       ...receipt,
-      content: { type: 'image', src: `data:image/jpeg;base64,${'A'.repeat(120_000)}` },
+      content: { type: 'text', text: 'a very long letter. '.repeat(1000) },
     })
-    const attempt = tryEncodePaperShare('photo', withUpload)
+    expect(refusal('letter', long).reason).toBe('too-long')
+    expect(refusal('photo', upload(120_000)).reason).toBe('uploaded-image')
+  })
+
+  it('finds an upload printed on the reverse of the sheet', () => {
+    // `content.back` is a second content union with its own image variant.
+    // Reading `content.src` alone would call this one merely too long and
+    // send someone looking for a picture they would not find there.
+    const backed = paperConfigSchema.parse({
+      ...receipt,
+      content: {
+        type: 'text',
+        text: 'front',
+        back: { type: 'image', src: `data:image/jpeg;base64,${'A'.repeat(120_000)}` },
+      },
+    })
+    expect(refusal('backed', backed).reason).toBe('uploaded-image')
+  })
+
+  it('reports how long the link would have been, for a message that can say', () => {
+    expect(refusal('photo', upload(120_000)).length).toBeGreaterThan(MAX_SHARE_LENGTH)
+  })
+
+  it('hands the refusal back through paperShareUrl rather than a bare null', () => {
+    const attempt = paperShareUrl('https://paperlab.dev/editor/', 'photo', upload(120_000))
     expect(attempt.ok).toBe(false)
     if (attempt.ok) throw new Error('expected a refusal')
-    expect(attempt.reason).toBe('too-long')
-    expect(paperShareUrl('https://paperlab.dev/editor/', 'photo', withUpload)).toBeNull()
+    expect(attempt.reason).toBe('uploaded-image')
   })
 
   it('accepts a paper that fits', () => {
     const attempt = tryEncodePaperShare('receipt', receipt)
     expect(attempt.ok).toBe(true)
+  })
+
+  it('does not mistake an image URL for an upload', () => {
+    // A referenced picture is exactly what DOES travel in a link. Only the
+    // bytes-in-the-config case is the one that cannot.
+    const linked = paperConfigSchema.parse({
+      ...receipt,
+      content: { type: 'image', src: 'https://example.com/photo.jpg' },
+    })
+    expect(tryEncodePaperShare('linked', linked).ok).toBe(true)
   })
 })
 
@@ -96,21 +149,28 @@ describe('decoding a link nobody should trust', () => {
   })
 })
 
+/** The url of a share that is expected to succeed. */
+function shareUrl(base: string, name: string, config: Parameters<typeof paperShareUrl>[2]): string {
+  const attempt = paperShareUrl(base, name, config)
+  if (!attempt.ok) throw new Error(`expected a link, got ${attempt.reason}`)
+  return attempt.url
+}
+
 describe('links', () => {
   it('puts the paper in the query and reads it back', () => {
-    const url = paperShareUrl('https://paperlab.dev/editor/', 'my receipt', receipt)!
+    const url = shareUrl('https://paperlab.dev/editor/', 'my receipt', receipt)
     expect(new URL(url).searchParams.get(SHARE_PARAM)).toBeTruthy()
     expect(readPaperShare(new URL(url).search)?.name).toBe('my receipt')
   })
 
   it('keeps whatever was already on the url', () => {
-    const url = paperShareUrl('https://paperlab.dev/editor/?utm=x', 'r', receipt)!
+    const url = shareUrl('https://paperlab.dev/editor/?utm=x', 'r', receipt)
     expect(new URL(url).searchParams.get('utm')).toBe('x')
   })
 
   it('replaces rather than stacks when re-sharing an opened link', () => {
-    const first = paperShareUrl('https://paperlab.dev/editor/', 'a', receipt)!
-    const second = paperShareUrl(first, 'b', receipt)!
+    const first = shareUrl('https://paperlab.dev/editor/', 'a', receipt)
+    const second = shareUrl(first, 'b', receipt)
     expect(new URL(second).searchParams.getAll(SHARE_PARAM)).toHaveLength(1)
     expect(readPaperShare(new URL(second).search)?.name).toBe('b')
   })

--- a/apps/editor/src/state/paperShare.ts
+++ b/apps/editor/src/state/paperShare.ts
@@ -53,20 +53,46 @@ export function encodePaperShare(name: string, config: PaperConfig): string {
 }
 
 /**
- * Why a paper might not fit in a link. An uploaded image becomes a data URL
- * inside the config, and a downscaled JPEG is still ~100 KB — far past what
- * a URL survives. That is worth saying plainly rather than silently
- * producing a link that breaks on paste.
+ * Does this config carry an uploaded FILE rather than a reference to one?
+ *
+ * Walked generically rather than by reading `content.src`, because `src` is
+ * not the only place a data URL can reach: `content.back` is a second whole
+ * content union with its own image variant, and any field that later learns
+ * to hold a bitmap should not quietly start producing links that break on
+ * paste. A false negative here is a wrong explanation shown to someone whose
+ * share just failed, which is worse than no explanation.
  */
-export type ShareRefusal = 'too-long'
+function carriesUpload(value: unknown): boolean {
+  if (typeof value === 'string') return value.startsWith('data:')
+  if (Array.isArray(value)) return value.some(carriesUpload)
+  if (value && typeof value === 'object') return Object.values(value).some(carriesUpload)
+  return false
+}
+
+/**
+ * Why a paper might not fit in a link.
+ *
+ * Two reasons, and they need different advice, which is the whole point of
+ * telling them apart. An uploaded image becomes a data URL inside the config
+ * and a downscaled JPEG is still ~100KB — no amount of editing will get that
+ * under the cap, so the answer is to send the file. A paper that is merely
+ * long can be shortened, and saying "this carries an uploaded image" to
+ * someone who never uploaded one sends them looking for a picture that is
+ * not there.
+ */
+export type ShareRefusal = 'uploaded-image' | 'too-long'
 
 export function tryEncodePaperShare(
   name: string,
   config: PaperConfig,
-): { ok: true; encoded: string } | { ok: false; reason: ShareRefusal } {
+): { ok: true; encoded: string } | { ok: false; reason: ShareRefusal; length: number } {
   const encoded = encodePaperShare(name, config)
-  if (encoded.length > MAX_SHARE_LENGTH) return { ok: false, reason: 'too-long' }
-  return { ok: true, encoded }
+  if (encoded.length <= MAX_SHARE_LENGTH) return { ok: true, encoded }
+  return {
+    ok: false,
+    reason: carriesUpload(diffConfig(config)) ? 'uploaded-image' : 'too-long',
+    length: encoded.length,
+  }
 }
 
 /**
@@ -93,14 +119,23 @@ export function decodePaperShare(encoded: string): PaperShare | null {
   return { name: n.trim(), config: c as PaperConfigInput }
 }
 
-export function paperShareUrl(base: string, name: string, config: PaperConfig): string | null {
+/**
+ * The link, or why there isn't one. The refusal travels with the URL rather
+ * than collapsing to null, because the caller has to say something specific
+ * to whoever just pressed Share — and a null cannot tell it what.
+ */
+export function paperShareUrl(
+  base: string,
+  name: string,
+  config: PaperConfig,
+): { ok: true; url: string } | { ok: false; reason: ShareRefusal; length: number } {
   const attempt = tryEncodePaperShare(name, config)
-  if (!attempt.ok) return null
+  if (!attempt.ok) return attempt
   const url = new URL(base)
   // A shared paper replaces whatever was on the URL before, so re-sharing
   // an opened link does not stack parameters.
   url.searchParams.set(SHARE_PARAM, attempt.encoded)
-  return url.toString()
+  return { ok: true, url: url.toString() }
 }
 
 export function readPaperShare(search: string): PaperShare | null {

--- a/apps/editor/src/state/store.ts
+++ b/apps/editor/src/state/store.ts
@@ -35,6 +35,7 @@ import {
   loadUserPresets,
   persistUserPresets,
   syncRegistry,
+  type PersistOutcome,
   type StoredPreset,
   type UserPresetMap,
 } from './userPresets'
@@ -150,13 +151,13 @@ interface EditorState {
   backToField(): void
   userPresets: UserPresetMap
   /** Save (or overwrite) a user preset; rejects built-in names. */
-  savePreset(name: string, config: PaperConfig, thumbnail?: string): string | null
+  savePreset(name: string, config: PaperConfig, thumbnail?: string): SaveOutcome
   duplicatePreset(source: string): void
   deletePreset(name: string): void
   renamePreset(oldName: string, newName: string): string | null
-  importPreset(json: string): string | null
-  /** Adopt a paper that arrived on the URL. Returns an error, or null. */
-  importSharedPaper(share: PaperShare): string | null
+  importPreset(json: string): SaveOutcome
+  /** Adopt a paper that arrived on the URL. */
+  importSharedPaper(share: PaperShare): SaveOutcome
   /** Bumped when the canvas changes params behind the inspector's back (handle drags, transport commits) — remounts the inspector. */
   inspectorEpoch: number
   setPreset(name: string): void
@@ -168,6 +169,25 @@ interface EditorState {
   setPhysics(name: string): void
   patchCloth(patch: Partial<ClothConfig>): void
 }
+
+/**
+ * What came of trying to store a paper.
+ *
+ * Two failures that used to look identical to a caller, and must not: a
+ * REJECTED save stored nothing and the reason is the user's to fix (a name
+ * that is taken, a file that will not parse), while a save that reached the
+ * registry but not the disk is a real save the user still needs warned
+ * about. Both used to come back as `string | null`, so the second one could
+ * only ever be reported as the success it partly is.
+ *
+ * The stored config travels on the success arm so whoever reports it can
+ * offer the `.paper` file — the same escape hatch a refused share offers,
+ * and for the same reason: the file is what survives when the browser will
+ * not hold the thing.
+ */
+export type SaveOutcome =
+  | { ok: false; error: string }
+  | { ok: true; name: string; config: PaperConfigInput; storage: PersistOutcome }
 
 export interface WriteOpts {
   /** The canvas changed params behind the inspector's back — remount it. */
@@ -493,21 +513,31 @@ export const useEditor = create<EditorState>((set, get) => ({
 
   savePreset: (name, config, thumbnail) => {
     const trimmed = name.trim()
-    if (!trimmed) return 'Preset needs a name.'
-    if (isBuiltinPreset(trimmed)) return `"${trimmed}" is a built-in — pick another name.`
+    if (!trimmed) return { ok: false, error: 'Preset needs a name.' }
+    if (isBuiltinPreset(trimmed)) {
+      return { ok: false, error: `"${trimmed}" is a built-in — pick another name.` }
+    }
     const named = paperConfigSchema.parse({ ...config, meta: { ...config.meta, name: trimmed } })
     const stored: StoredPreset = {
       config: diffConfig(named),
       thumbnail,
       savedAt: new Date().toISOString(),
     }
-    set((s) => {
-      const userPresets = { ...s.userPresets, [trimmed]: stored }
-      persistUserPresets(userPresets)
-      syncRegistry(userPresets)
-      return { userPresets, presetName: trimmed, config: named, inspectorEpoch: s.inspectorEpoch + 1 }
-    })
-    return null
+    // Written OUTSIDE the set() updater. A zustand updater is a pure
+    // function of state that may be invoked more than once, and this one was
+    // doing two side effects in it — a localStorage write and a registry
+    // sync — neither of which has an answer it could return from in there.
+    // The storage outcome is exactly what the caller now has to report.
+    const userPresets = { ...get().userPresets, [trimmed]: stored }
+    const storage = persistUserPresets(userPresets)
+    syncRegistry(userPresets)
+    set((s) => ({
+      userPresets,
+      presetName: trimmed,
+      config: named,
+      inspectorEpoch: s.inspectorEpoch + 1,
+    }))
+    return { ok: true, name: trimmed, config: stored.config, storage }
   },
 
   duplicatePreset: (source) => {
@@ -575,9 +605,12 @@ export const useEditor = create<EditorState>((set, get) => ({
     try {
       return get().savePreset(name, paperConfigSchema.parse(share.config))
     } catch (error) {
-      return `That link isn't a paper this build can open: ${
-        error instanceof Error ? error.message.slice(0, 120) : error
-      }`
+      return {
+        ok: false,
+        error: `That link isn't a paper this build can open: ${
+          error instanceof Error ? error.message.slice(0, 120) : error
+        }`,
+      }
     }
   },
   importPreset: (json) => {
@@ -589,7 +622,10 @@ export const useEditor = create<EditorState>((set, get) => ({
       const name = uniquePresetName(base, (n) => isBuiltinPreset(n) || Boolean(get().userPresets[n]))
       return get().savePreset(name, config)
     } catch (error) {
-      return `Not a valid .paper file: ${error instanceof Error ? error.message.slice(0, 120) : error}`
+      return {
+        ok: false,
+        error: `Not a valid .paper file: ${error instanceof Error ? error.message.slice(0, 120) : error}`,
+      }
     }
   },
 }))

--- a/apps/editor/src/state/userPresets.test.ts
+++ b/apps/editor/src/state/userPresets.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { loadUserPresets, persistUserPresets, type UserPresetMap } from './userPresets'
+
+/**
+ * vitest runs in node, so localStorage is stubbed — with a byte budget,
+ * because the outcome under test is precisely what happens as a real
+ * browser's quota runs out.
+ */
+function stubStorage(limit = Number.POSITIVE_INFINITY) {
+  const map = new Map<string, string>()
+  const storage = {
+    getItem: (k: string) => map.get(k) ?? null,
+    removeItem: (k: string) => void map.delete(k),
+    setItem: (k: string, v: string) => {
+      if (v.length > limit) throw new Error('QuotaExceededError')
+      map.set(k, v)
+    },
+    raw: map,
+  }
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+  return storage
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'localStorage')
+})
+
+const preset = (thumbnailBytes: number): UserPresetMap => ({
+  mine: {
+    config: { meta: { name: 'mine' } },
+    thumbnail: `data:image/jpeg;base64,${'A'.repeat(thumbnailBytes)}`,
+    savedAt: '2026-08-24T00:00:00.000Z',
+  },
+})
+
+describe('persisting user presets', () => {
+  it('reports a clean write', () => {
+    const storage = stubStorage()
+    expect(persistUserPresets(preset(100))).toBe('stored')
+    expect(storage.raw.size).toBe(1)
+  })
+
+  it('drops thumbnails to fit, and says that is what it did', () => {
+    // Budget sits between the full record (519 bytes) and the same record
+    // without its picture (81), so the retry is the write that lands.
+    stubStorage(200)
+    expect(persistUserPresets(preset(400))).toBe('thumbnails-dropped')
+  })
+
+  it('keeps the config when it drops the thumbnail', () => {
+    // The retry must shed the picture and nothing else — a preset that
+    // survives as a name with no paper attached is not a preset that survived.
+    const storage = stubStorage(200)
+    persistUserPresets(preset(400))
+    const written = JSON.parse([...storage.raw.values()][0]!) as UserPresetMap
+    expect(written.mine?.thumbnail).toBeUndefined()
+    expect(written.mine?.config).toEqual({ meta: { name: 'mine' } })
+  })
+
+  it('reports session-only when even the slim write will not fit', () => {
+    // The case that used to be swallowed and shown to the user as "Saved":
+    // the preset is live in the registry, and nothing reached the disk.
+    stubStorage(10)
+    expect(persistUserPresets(preset(400))).toBe('session-only')
+  })
+
+  it('reports session-only rather than throwing where there is no storage', () => {
+    // Private windows and embedded webviews reach the accessor and throw.
+    expect(() => persistUserPresets(preset(10))).not.toThrow()
+    expect(persistUserPresets(preset(10))).toBe('session-only')
+  })
+
+  it('reads back what it wrote', () => {
+    stubStorage()
+    persistUserPresets(preset(10))
+    expect(Object.keys(loadUserPresets())).toEqual(['mine'])
+  })
+
+  it('drops a record the schema no longer accepts instead of failing the load', () => {
+    const storage = stubStorage()
+    storage.setItem(
+      'paperlab.userPresets.v1',
+      JSON.stringify({ good: preset(10).mine, bad: { config: { sheet: { width: 'wide' } } } }),
+    )
+    expect(Object.keys(loadUserPresets())).toEqual(['good'])
+  })
+})

--- a/apps/editor/src/state/userPresets.ts
+++ b/apps/editor/src/state/userPresets.ts
@@ -34,9 +34,24 @@ export function loadUserPresets(): UserPresetMap {
   }
 }
 
-export function persistUserPresets(presets: UserPresetMap): void {
+/**
+ * What became of a write to localStorage.
+ *
+ * `session-only` is the one that matters. The presets are live in the
+ * registry and fully editable, but nothing reached disk, so they die with
+ * the tab. That outcome used to be swallowed here and reported to the user
+ * as a plain "Saved" — the worst shape a failure can have, because the way
+ * you find out is by losing the work.
+ *
+ * It is reachable: an uploaded image lands in a config as a data URL of
+ * ~100KB and up, and a handful of those clears a 5MB quota.
+ */
+export type PersistOutcome = 'stored' | 'thumbnails-dropped' | 'session-only'
+
+export function persistUserPresets(presets: UserPresetMap): PersistOutcome {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(presets))
+    return 'stored'
   } catch {
     // Quota exceeded (thumbnails add up) — drop thumbnails and retry once.
     const slim: UserPresetMap = {}
@@ -45,8 +60,9 @@ export function persistUserPresets(presets: UserPresetMap): void {
     }
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(slim))
+      return 'thumbnails-dropped'
     } catch {
-      /* out of options — presets stay session-only */
+      return 'session-only'
     }
   }
 }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1155,6 +1155,39 @@ button.export:hover {
   outline: none;
 }
 
+/* An uncommitted text draft, said twice — the label takes a brighter step
+   (rule 4: emphasis is a step on the white ladder, never a hue) and the
+   textarea grows the Apply button below. */
+.control-row.dirty .control-label {
+  color: var(--ink);
+}
+
+.control-apply {
+  justify-self: end;
+  background: var(--lift-2);
+  border: 1px solid var(--hair-2);
+  border-radius: 4px;
+  color: var(--ink);
+  font: inherit;
+  font-size: 11px;
+  padding: 3px 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.control-apply:hover {
+  background: var(--lift-3);
+  border-color: var(--ink-body);
+}
+
+.control-apply kbd {
+  color: var(--ink-meta);
+  font: inherit;
+  font-size: 10px;
+}
+
 .control-toggle {
   grid-column: 2 / -1;
   justify-self: start;

--- a/packages/paperlab/src/config/schema.test.ts
+++ b/packages/paperlab/src/config/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { paperConfigSchema } from './schema'
+import { contentNames, contentSchemaFor, paperConfigSchema } from './schema'
 import { mergeConfig, mergeWithDeletes, parsePreset, serializePreset } from './serialize'
 import {
   getPreset,
@@ -164,5 +164,50 @@ describe('uniquePresetName', () => {
   it('walks past every taken suffix', () => {
     const taken = new Set(['note copy', 'note copy 2', 'note copy 3'])
     expect(uniquePresetName('note copy', (n) => taken.has(n))).toBe('note copy 4')
+  })
+})
+
+describe('content variants', () => {
+  it('names every member of the union, and only those', () => {
+    // Read off the union rather than written beside it, so a sixth content
+    // type cannot ship with an editor that refuses to offer it.
+    expect([...contentNames].sort()).toEqual(['blank', 'card', 'image', 'receipt', 'text'])
+  })
+
+  it('hands back the variant carrying each discriminator', () => {
+    for (const name of contentNames) {
+      expect(contentSchemaFor(name).shape.type.value).toBe(name)
+    }
+  })
+
+  it('throws on a type the union does not carry', () => {
+    expect(() => contentSchemaFor('poster' as never)).toThrow(/Unknown content type/)
+  })
+
+  it('every variant parses from its discriminator alone', () => {
+    // This is the whole contract behind the inspector's type selector: the
+    // patch it writes is `{ type }` and nothing else, and the schema is
+    // expected to fill the rest.
+    for (const name of contentNames) {
+      const parsed = paperConfigSchema.parse({ content: { type: name } }).content
+      expect(parsed.type).toBe(name)
+    }
+  })
+
+  it('fills the receipt a preset would ship with', () => {
+    const content = paperConfigSchema.parse({ content: { type: 'receipt' } }).content
+    expect(content).toMatchObject({ type: 'receipt', store: 'PAPERLAB', barcode: true })
+    expect(content.type === 'receipt' && content.items.length).toBeGreaterThan(0)
+  })
+
+  it('switching type leaves no field of the old variant behind', () => {
+    // mergeWithDeletes replaces a differing `type` wholesale; if it ever
+    // merged instead, a receipt would carry the image's `src` into an export.
+    const image = paperConfigSchema.parse({ content: { type: 'image', src: 'photo.jpg' } })
+    const receipt = paperConfigSchema.parse(
+      mergeWithDeletes(image as Record<string, unknown>, { content: { type: 'receipt' } }),
+    )
+    expect(receipt.content.type).toBe('receipt')
+    expect(receipt.content).not.toHaveProperty('src')
   })
 })

--- a/packages/paperlab/src/config/schema.ts
+++ b/packages/paperlab/src/config/schema.ts
@@ -214,6 +214,34 @@ export type ContentConfig = z.infer<typeof contentSchema>
 /** What a caller may WRITE — defaults still unfilled. This is the prop type. */
 export type ContentConfigInput = z.input<typeof contentSchema>
 
+/**
+ * Every kind of thing that can print on a sheet, in declaration order.
+ *
+ * Read off the union rather than written out beside it. The sibling name
+ * lists here (`stockNames`, `physicsNames`) are the SOURCE their schema is
+ * built from, so a hand-written array is the single source of truth; this
+ * one is not — the union is — and a second copy would be free to drift the
+ * day a sixth content type lands.
+ */
+export const contentNames = contentSchema.options.map(
+  (option) => option.shape.type.value,
+) as readonly ContentConfig['type'][]
+
+/**
+ * One variant's schema, by its `type`.
+ *
+ * Exists so that a caller GENERATING UI from the schema — the editor's
+ * inspector already does this for behaviors, layouts and the stage — can
+ * reach a content variant without reaching into the union's internals.
+ * Which member carries which discriminator is the union's own fact to
+ * state, not a walk's to rediscover.
+ */
+export function contentSchemaFor(type: ContentConfig['type']): (typeof contentSchema)['options'][number] {
+  const option = contentSchema.options.find((candidate) => candidate.shape.type.value === type)
+  if (!option) throw new Error(`Unknown content type: ${type}`)
+  return option
+}
+
 // ── Surface ──────────────────────────────────────────────────────────────────
 
 export const paperEdges = ['top', 'right', 'bottom', 'left'] as const

--- a/packages/paperlab/src/index.ts
+++ b/packages/paperlab/src/index.ts
@@ -44,6 +44,8 @@ export {
   physicsNames,
   lightingNames,
   stockNames,
+  contentNames,
+  contentSchemaFor,
   paperEdges,
   coreStateNames,
   type PaperConfig,


### PR DESCRIPTION
Four changes, in the order they were found. The first two are the ones asked for; the last two are problems the first two surfaced.

## Content is five types, not two (`b1abe68`)

The Content folder was the one branch of the config still hand-written, and it had grown UI for two of the five content types. `blank`, `card` and `receipt` fell through to `return []` — so the app's own default paper, a receipt, opened Content onto nothing. There was no type selector either, so which kind of thing printed on a sheet was decided entirely by whichever preset had been loaded, and the image upload that already existed was unreachable unless that preset happened to be image content.

Content now opens with a type selector, and everything under it is generated by `schemaControls()` — the same walk that already gives behaviors, layouts and the stage their panels for free. The library publishes `contentNames` and `contentSchemaFor` to make that possible (`minor`; changeset included).

Four fields stay hand-built, because they are the four the walk cannot state well: `src` masks an uploaded data URL and carries the upload button, `text` and `body` are prose and want a textarea, and `items` is an array of objects, which the walk does not do at all. They sit ahead of the generated rest on a rule worth keeping — the content itself, then how it is set.

The receipt's items are one textarea, `NAME | PRICE` per line. Its parser is its own module because it is the only part of this folder that can be *wrong*: it splits on the last pipe so a name may contain one, strips the currency symbols people actually type, reads a half-typed line as a name with no price yet, and falls back to 0 rather than NaN — NaN fails the schema parse and takes the render down with it.

Switching type cannot leak a field across variants: `mergeWithDeletes` already replaces a discriminated union wholesale when `type` differs. Pinned by a test, because that is load-bearing now in a way it was not when nothing could switch types.

| type | fields now editable |
|---|---|
| `receipt` | items, store, address, taxRate, barcode, timestamp, footer |
| `card` | body, title, note, rule, ruled, font, size, color, align, padding |
| `text` | text, font, size, weight, color, align, padding, lineHeight, tracking, valign |
| `image` | src, upload image, fit, alt |
| `blank` | — |

## A text draft that says it has not been applied yet (`e1138ac`)

Text commits on blur rather than per keystroke, and that model is right: the canvas rebuilds its content texture on every change.

What was missing was any way to *see* it, and on the textarea any way to trigger it. The one-line input had Enter → blur → commit; the textarea had nothing, because Enter is a newline there. Content text is `rows: 4`, which made the most-used field in the app the one with no commit path at all.

An uncommitted draft now says so twice: the label takes a brighter step and the textarea grows an Apply button. Both appear only while dirty. ⌘/Ctrl+Enter is the keyboard path and the button names it; Escape abandons the draft.

Apply commits on mousedown, not click — clicking blurs the textarea first, which commits, which un-dirties, which unmounts the button before its own click lands. `preventDefault` keeps the caret where it was.

Emphasis is a step on the white ladder rather than a hue, so the chroma budget still buys exactly one thing (`docs/design.md` rule 4).

## A share that fails says why, and offers the way out (`2fae141`)

Sharing already refused a paper too big for a URL. Two things were wrong with the refusal.

It **guessed the reason**. `paperShareUrl` collapsed every failure to `null` and the caller told everyone the same story — "this paper carries an uploaded image" — which is a lie to anyone whose paper is merely long. Roughly 5,900 characters of text is over the cap. The refusal now carries its reason and the length it needed, and the upload check walks the config generically rather than reading `content.src`, because `content.back` is a second content union with its own image variant.

And the advice **was not followable**. Both refusals end at the `.paper` file, which does carry the image — but `downloadPreset` was reachable only from a *saved* preset in the left panel, three steps and two panels from the button you pressed. Share deliberately works on an unsaved sculpt precisely because making people save first stops things from being sent at all. The refusal is now a dialog with the download on it.

## A preset that did not reach the disk stops saying "Saved" (`3e9d3be`)

`persistUserPresets` returned void and swallowed its own failure. When localStorage was full it dropped thumbnails and retried, and if that failed too it gave up in a comment — while `savePreset` returned null, which the caller reads as success and reports as `Saved "x"`. The preset is live in the registry and completely convincing until the tab closes. The way you found out was by losing the work.

Not theoretical now that any sheet can carry an uploaded image: a data URL is ~100KB and up, and a handful clears 5MB.

The write now reports what became of it — `stored`, `thumbnails-dropped`, or `session-only` — and every entry point into the preset store reports through one place. Only `session-only` interrupts, and its dialog carries the same escape hatch a refused share does.

`savePreset` also stopped doing its side effects inside a zustand `set` updater. An updater is a pure function of state that may be invoked more than once, and that one was running a localStorage write and a registry sync in it.

## Verification

`lint` · `typecheck` · `knip` clean. **734 tests pass** (28 new).

Driven in a real browser, not just asserted:

- all five content types render their full field sets, no console errors
- upload → the sheet shows the picture; applied text reaches the sheet
- Apply: hidden when clean, appears when dirty, click applies and keeps focus, ⌘↵ applies, Escape abandons
- share refusal → dialog → the downloaded `.paper` really does carry the image it promises
- quota genuinely exhausted → all three storage outcomes, and after a reload the preset the warning said would not survive did not survive, while the one saved with room to spare did

🤖 Generated with [Claude Code](https://claude.com/claude-code)