### PR TITLE
Export the frame as a picture

### DIFF
--- a/.changeset/handles-are-not-artwork.md
+++ b/.changeset/handles-are-not-artwork.md
@@ -1,0 +1,17 @@
+---
+'paperlab': patch
+---
+
+Mark the interactive drag handle as chrome, so a renderer producing a picture
+can leave it out.
+
+The handle is drawn with `depthTest: false` on purpose — it has to sit on top
+of the sheet to be grabbable where the sheet curls away. That also makes it the
+single most prominent thing in any frame captured off the canvas, which is how
+the editor's new image export came out with a blue dot in the middle of the
+receipt.
+
+`userData.paperlabChrome` says what the object IS — an editing affordance
+rather than part of the artwork — instead of asking every capture path to know
+this one mesh by sight. Nothing reads it unless it wants to; the flag is inert
+for every existing consumer.

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -32,6 +32,7 @@ import { PresetPanel } from './panels/PresetPanel'
 import { ViewportGuide } from './chrome/ViewportGuide'
 import { CoachMark, HandleAnchor, coachMarkUsed } from './chrome/CoachMark'
 import { CameraRig, ViewCluster } from './chrome/ViewCluster'
+import { CaptureRig, type CaptureHandle } from './chrome/CaptureRig'
 import { SmallScreen } from './chrome/SmallScreen'
 import { captureThumbnail, downloadPreset } from './state/userPresets'
 import { MAX_SHARE_LENGTH, SHARE_PARAM, paperShareUrl, readPaperShare } from './state/paperShare'
@@ -82,6 +83,7 @@ export function App() {
   const editFieldPaper = useEditor((s) => s.editFieldPaper)
   const backToField = useEditor((s) => s.backToField)
   const savePreset = useEditor((s) => s.savePreset)
+  const captureRef = useRef<CaptureHandle | null>(null)
   const editingState = useEditor((s) => s.editingState)
   const statePreview = useEditor((s) => s.statePreview)
   const selectedSlot = useEditor((s) => s.selectedSlot)
@@ -297,6 +299,7 @@ export function App() {
           mode={mode}
           config={config}
           paperRef={paperRef}
+          captureRef={captureRef}
           fieldInput={fieldExportInput}
           stageInput={stageExportInput}
         />
@@ -444,6 +447,7 @@ export function App() {
               zones={fieldZones}
             />
           )}
+          <CaptureRig handleRef={captureRef} />
           {mode === 'paper' && <HandleAnchor paperRef={paperRef} />}
           {/* Stage walks its own camera; the other two modes orbit, and the
               cluster below the canvas is how anyone finds that out. */}

--- a/apps/editor/src/chrome/CaptureRig.tsx
+++ b/apps/editor/src/chrome/CaptureRig.tsx
@@ -1,0 +1,108 @@
+import { useThree } from '@react-three/fiber'
+import { useEffect, useRef } from 'react'
+import type { Object3D, PerspectiveCamera } from 'three'
+import { fitFov } from './imageExport'
+
+export interface CaptureHandle {
+  /** Render the live scene at an exact pixel size; resolves a PNG data URL. */
+  capture(width: number, height: number): Promise<string>
+}
+
+/**
+ * Renders one frame at an exact size and reads it back. Lives INSIDE the
+ * canvas because everything it needs — the renderer, the camera, r3f's own
+ * size state — is only reachable from in there.
+ *
+ * Two decisions carry the whole thing:
+ *
+ * **It resizes through r3f rather than through the renderer.** `gl.setSize`
+ * is the obvious call and it is the wrong one: stage mode mounts an
+ * `EffectComposer`, which sizes its buffers off r3f's `size` state, so a
+ * renderer resized behind its back composites a new frame through an old
+ * buffer. `setSize` moves both.
+ *
+ * **It lets the app's own loop draw the frame** instead of calling
+ * `gl.render`. A direct render skips the composer entirely, which for stage
+ * mode means exporting an ungraded picture of a scene whose grade is most of
+ * how it looks. Waiting for the buffer to be the size we asked for, and then
+ * for a frame drawn at that size, works the same in all three modes.
+ *
+ * Reading it back at all depends on `preserveDrawingBuffer: true` on the
+ * editor's canvas — without it the buffer is cleared before anything outside
+ * the render can see it. `captureThumbnail` already relies on the same flag.
+ */
+export function CaptureRig({ handleRef }: { handleRef: React.RefObject<CaptureHandle | null> }) {
+  const state = useThree()
+  // The handle is installed once and called much later; keep it reading the
+  // live renderer rather than the one that existed when it was installed.
+  const latest = useRef(state)
+  latest.current = state
+
+  useEffect(() => {
+    handleRef.current = {
+      async capture(width: number, height: number) {
+        const { camera, scene, size, setSize, setDpr, viewport } = latest.current
+        const restore = { width: size.width, height: size.height, dpr: viewport.dpr }
+        const perspective = camera as PerspectiveCamera
+        const fov = perspective.fov
+        // Editing affordances are not artwork. The grab handle is drawn with
+        // `depthTest: false` so that it sits on top of the sheet, which makes
+        // it the single most prominent thing in an exported picture — a blue
+        // dot in the middle of the receipt you were about to post.
+        const chrome: Object3D[] = []
+        scene.traverse((object) => {
+          if (object.userData.paperlabChrome && object.visible) chrome.push(object)
+        })
+        try {
+          for (const object of chrome) object.visible = false
+          // Set before the resize: r3f recomputes the projection as part of
+          // handling the new size, so both changes land in one update.
+          perspective.fov = fitFov(fov, size.width / size.height, width / height)
+          // Device pixel ratio is the viewport's business, not the file's —
+          // the requested size IS the pixel size, on any monitor.
+          setDpr(1)
+          setSize(width, height)
+          await drawnAt(width, height)
+          return latest.current.gl.domElement.toDataURL('image/png')
+        } finally {
+          for (const object of chrome) object.visible = true
+          perspective.fov = fov
+          setDpr(restore.dpr)
+          setSize(restore.width, restore.height)
+        }
+      },
+    }
+    return () => {
+      handleRef.current = null
+    }
+  }, [handleRef])
+
+  return null
+}
+
+/**
+ * Wait until the drawing buffer is the size we asked for, then for a frame
+ * actually drawn at it.
+ *
+ * Polled rather than given a fixed number of frames, because the resize
+ * crosses a React commit and "how many frames is that" is a guess that is
+ * only ever wrong on a slow machine — the failure being a captured image at
+ * the OLD size, which looks like a working feature that ignores the frame
+ * you picked. The budget is a ceiling, not a wait: it gives up rather than
+ * hanging if a resize is refused (a size past the GPU's limit).
+ */
+function drawnAt(width: number, height: number, budget = 90): Promise<void> {
+  return new Promise((resolve) => {
+    let left = budget
+    let settled = 0
+    const tick = () => {
+      const canvas = document.querySelector<HTMLCanvasElement>('.viewport canvas')
+      if (canvas && canvas.width === width && canvas.height === height) settled++
+      // Two frames at the right size: the first is the one that resized, the
+      // second is the one drawn into it.
+      if (settled >= 2 || left-- <= 0) resolve()
+      else requestAnimationFrame(tick)
+    }
+    requestAnimationFrame(tick)
+  })
+}

--- a/apps/editor/src/chrome/imageExport.test.ts
+++ b/apps/editor/src/chrome/imageExport.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { EXPORT_FRAMES, fitFov, imageFilename } from './imageExport'
+
+/** The horizontal half-extent a camera sees at unit distance. */
+const horizontal = (fov: number, aspect: number) => Math.tan((fov * Math.PI) / 360) * aspect
+
+describe('fitFov', () => {
+  it('leaves a matching aspect alone', () => {
+    expect(fitFov(40, 16 / 9, 16 / 9)).toBeCloseTo(40)
+  })
+
+  it('leaves a wider target alone — it already shows everything', () => {
+    expect(fitFov(40, 1, 16 / 9)).toBe(40)
+  })
+
+  it('opens the field for a narrower target', () => {
+    expect(fitFov(40, 16 / 9, 9 / 16)).toBeGreaterThan(40)
+  })
+
+  it('keeps the horizontal extent exactly, which is the point', () => {
+    // Nothing that was on screen to the left or right may leave the frame.
+    const from = 16 / 9
+    const to = 9 / 16
+    expect(horizontal(fitFov(40, from, to), to)).toBeCloseTo(horizontal(40, from), 6)
+  })
+
+  it('never crops horizontally for any frame the menu offers', () => {
+    const viewport = 1400 / 900
+    for (const frame of EXPORT_FRAMES) {
+      const to = frame.width / frame.height
+      const fitted = horizontal(fitFov(40, viewport, to), to)
+      expect(fitted).toBeGreaterThanOrEqual(horizontal(40, viewport) - 1e-9)
+    }
+  })
+
+  it('returns the fov untouched on degenerate input rather than NaN', () => {
+    // A zero-height viewport happens for a frame or two while a panel mounts,
+    // and a NaN fov silently blanks the canvas instead of throwing.
+    expect(fitFov(40, 0, 1)).toBe(40)
+    expect(fitFov(40, 1, 0)).toBe(40)
+    expect(fitFov(0, 1, 2)).toBe(0)
+  })
+})
+
+describe('imageFilename', () => {
+  it('slugs a preset name the way the .paper download does', () => {
+    expect(imageFilename('Receipt unroll', 'story')).toBe('receipt-unroll-story.png')
+  })
+
+  it('falls back rather than producing a dotfile', () => {
+    expect(imageFilename('   ', 'square')).toBe('paper-square.png')
+    expect(imageFilename('!!!', 'square')).toBe('paper-square.png')
+  })
+
+  it('does not leave leading or trailing dashes from stripped punctuation', () => {
+    expect(imageFilename('"quoted"', 'wide')).toBe('quoted-wide.png')
+  })
+})
+
+describe('the frames on offer', () => {
+  it('has a unique id per frame, since the id names the file', () => {
+    expect(new Set(EXPORT_FRAMES.map((f) => f.id)).size).toBe(EXPORT_FRAMES.length)
+  })
+
+  it('is sized for the places people post', () => {
+    for (const frame of EXPORT_FRAMES) {
+      expect(Math.max(frame.width, frame.height)).toBeLessThanOrEqual(2048)
+      expect(Math.min(frame.width, frame.height)).toBeGreaterThanOrEqual(1000)
+    }
+  })
+})

--- a/apps/editor/src/chrome/imageExport.ts
+++ b/apps/editor/src/chrome/imageExport.ts
@@ -1,0 +1,69 @@
+/**
+ * Exporting the frame as a picture.
+ *
+ * The library's answer to "how do I use this" ends in someone's codebase,
+ * and `ExportMenu` is built around that. This is the other half: the thing
+ * you post. A sheet that peels or unrolls is the most persuasive argument
+ * Paperlab has, and until now the only way to get one out of the editor was
+ * a screenshot of the whole application, chrome and all.
+ *
+ * The sizes are the ones the places people post to actually want, named for
+ * what they are rather than for their arithmetic.
+ */
+export interface ExportFrame {
+  id: string
+  label: string
+  hint: string
+  width: number
+  height: number
+}
+
+export const EXPORT_FRAMES: readonly ExportFrame[] = [
+  { id: 'square', label: 'Square', hint: '1:1 — a post', width: 1600, height: 1600 },
+  { id: 'portrait', label: 'Portrait', hint: '4:5 — the tallest a feed allows', width: 1600, height: 2000 },
+  { id: 'story', label: 'Story', hint: '9:16 — full screen on a phone', width: 1080, height: 1920 },
+  { id: 'wide', label: 'Wide', hint: '16:9 — a slide, a README, a site hero', width: 1920, height: 1080 },
+]
+
+/**
+ * The vertical field of view that keeps everything the viewport was showing.
+ *
+ * Aspect ratio is not a crop of the frame, it is a different frame, and a
+ * perspective camera holds its VERTICAL field fixed as the aspect changes —
+ * so exporting a wide viewport to 9:16 narrows the horizontal extent and
+ * quietly cuts the sides off the sheet you just composed. You would find out
+ * from the downloaded file.
+ *
+ * So a narrower target opens the field until the horizontal extent is the
+ * one that was on screen: the export reveals more above and below, and never
+ * less to the left and right. A wider or equal target is left alone, because
+ * it already shows everything the viewport did.
+ */
+export function fitFov(fov: number, fromAspect: number, toAspect: number): number {
+  if (!(fov > 0) || !(fromAspect > 0) || !(toAspect > 0)) return fov
+  if (toAspect >= fromAspect) return fov
+  const halfRadians = (fov * Math.PI) / 360
+  return (2 * Math.atan(Math.tan(halfRadians) * (fromAspect / toAspect)) * 180) / Math.PI
+}
+
+/**
+ * A filename someone can find again. Matches `downloadPreset`'s slug rules,
+ * so a paper's picture and its `.paper` file sit next to each other in a
+ * downloads folder rather than under two different spellings of one name.
+ */
+export function imageFilename(name: string, frameId: string): string {
+  const slug =
+    name
+      .trim()
+      .replace(/[^a-zA-Z0-9-_]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase() || 'paper'
+  return `${slug}-${frameId}.png`
+}
+
+export function downloadImage(dataUrl: string, filename: string): void {
+  const a = document.createElement('a')
+  a.href = dataUrl
+  a.download = filename
+  a.click()
+}

--- a/apps/editor/src/panels/ExportMenu.tsx
+++ b/apps/editor/src/panels/ExportMenu.tsx
@@ -16,28 +16,42 @@ import {
   diffStage,
   type StageExportInput,
 } from 'paperlab/stage'
+import type { CaptureHandle } from '../chrome/CaptureRig'
+import { EXPORT_FRAMES, downloadImage, imageFilename } from '../chrome/imageExport'
+import { toast } from '../controls/ui'
 /**
- * The tool's job ends in someone's codebase. Export serializes the ACTIVE
- * editor mode: a <Paper> in Paper mode, a <PaperField> (with every
+ * Two ways out of the editor, and they are for different people.
+ *
+ * The tool's job ends in someone's codebase, so the code half serializes the
+ * ACTIVE editor mode: a <Paper> in Paper mode, a <PaperField> (with every
  * referenced preset inlined) in Field mode, a <PaperStage> in Stage mode —
  * where the primary offer is the SCROLL-bound hero, because binding the walk
  * to the page is the thing people want and the fiddly thing to write.
+ *
+ * The picture half is what gets the codebase half looked at. A sheet that
+ * peels or unrolls is the most persuasive argument this library has, and the
+ * only way to get one out of the editor used to be a screenshot of the whole
+ * application. It sits first because it is the one you reach for on the way
+ * to showing someone, and the code is what you reach for once they ask.
  */
 export function ExportMenu({
   mode,
   config,
   paperRef,
+  captureRef,
   fieldInput,
   stageInput,
 }: {
   mode: 'paper' | 'field' | 'stage'
   config: PaperConfig
   paperRef: React.RefObject<PaperHandle | null>
+  captureRef: React.RefObject<CaptureHandle | null>
   fieldInput: () => FieldExportInput
   stageInput: () => StageExportInput
 }) {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState<string | null>(null)
+  const [rendering, setRendering] = useState<string | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -62,6 +76,30 @@ export function ExportMenu({
 
   const badge = (label: string) => (copied === label ? <span className="copied-badge">Copied ✓</span> : null)
 
+  const saveImage = async (frame: (typeof EXPORT_FRAMES)[number]) => {
+    const capture = captureRef.current
+    if (!capture) return
+    setRendering(frame.id)
+    try {
+      const dataUrl = await capture.capture(frame.width, frame.height)
+      // Named for what is IN the picture. Field and Stage are compositions of
+      // their own, and both were coming out named after whichever paper the
+      // Paper tab happened to be holding.
+      downloadImage(dataUrl, imageFilename(mode === 'paper' ? config.meta.name : mode, frame.id))
+      // The menu stays open — picking a second frame is the common next move,
+      // and the download itself is the confirmation.
+    } catch (error) {
+      // A frame past the GPU's texture limit, or a canvas the browser
+      // refuses to read back. Better named than silently doing nothing.
+      toast(
+        `Could not render that frame: ${error instanceof Error ? error.message.slice(0, 120) : error}`,
+        'error',
+      )
+    } finally {
+      setRendering(null)
+    }
+  }
+
   const fieldJson = () => {
     const input = fieldInput()
     return JSON.stringify(
@@ -80,10 +118,25 @@ export function ExportMenu({
   return (
     <div className="export-menu" ref={rootRef}>
       <button type="button" className="export" onClick={() => setOpen((v) => !v)}>
-        Export code
+        Export
       </button>
       {open && (
         <div className="export-dropdown">
+          <p className="export-group">Picture</p>
+          <div className="export-frames">
+            {EXPORT_FRAMES.map((frame) => (
+              <button
+                key={frame.id}
+                type="button"
+                disabled={rendering !== null}
+                onClick={() => void saveImage(frame)}
+              >
+                <strong>{frame.label}</strong>
+                <span>{rendering === frame.id ? 'rendering…' : frame.hint}</span>
+              </button>
+            ))}
+          </div>
+          <p className="export-group">Code</p>
           {mode === 'stage' ? (
             <>
               <button

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -415,6 +415,60 @@ button.export:hover {
   font-size: 11px;
 }
 
+/* Two exports now share one menu — a picture to post and code to ship — so
+   each half says which it is. A hairline label, not a heading: the menu is
+   250px of machine-register chrome, not a page. */
+.export-dropdown .export-group {
+  color: var(--ink-meta);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 9px 14px 5px;
+  border-top: 1px solid var(--hair);
+}
+
+.export-dropdown .export-group:first-child {
+  border-top: 0;
+}
+
+/* Four frames read as a set of choices, which a stack of full-width rows
+   does not — and the stack made the menu twice as tall as the canvas cluster
+   it hangs over. */
+.export-frames {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--hair);
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+}
+
+.export-frames button {
+  background: var(--l3);
+  padding: 9px 12px;
+  gap: 1px;
+}
+
+.export-frames button strong {
+  font-weight: 500;
+  color: var(--ink-2);
+}
+
+.export-frames button span {
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.export-frames button:disabled {
+  cursor: progress;
+  color: var(--ink-body);
+}
+
+.export-frames button:disabled:hover {
+  background: var(--l3);
+}
+
 /* "Copy for AI" is the hero path — promote it over the secondary two. */
 .export-dropdown .export-primary {
   position: relative;

--- a/packages/paperlab/src/PaperMesh.tsx
+++ b/packages/paperlab/src/PaperMesh.tsx
@@ -623,6 +623,12 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
         behavior?.handles?.map((h, i) => (
           <mesh
             key={h.id}
+            // Marked as chrome so a renderer that is producing a PICTURE can
+            // leave it out. The handle is an editing affordance, and it is
+            // drawn with `depthTest: false` precisely so it sits on top of
+            // the sheet — which makes it the most prominent thing in any
+            // frame captured for export. The editor's capture rig reads this.
+            userData={{ paperlabChrome: true }}
             ref={(m) => {
               handleRefs.current[i] = m
             }}

--- a/tools/share-loop-check.mjs
+++ b/tools/share-loop-check.mjs
@@ -92,7 +92,7 @@ try {
   check('refreshing does not duplicate it', afterReload === inLibrary, `${afterReload} preset(s)`)
 
   // ── The export half: what Bob does with it next. ───────────────────────
-  await b.getByRole('button', { name: 'Export code' }).click()
+  await b.getByRole('button', { name: 'Export', exact: true }).click()
   await b.waitForTimeout(400)
   const hasAi = await b.getByText('Copy for AI').isVisible()
   check('export is one click from the remix', hasAi)


### PR DESCRIPTION
Stacked on #52 — review that one first. GitHub will retarget this to `main` when #52 merges.

The library's answer to "how do I use this" ends in someone's codebase, and the export menu was built entirely around that. This is the other half: the thing you post. A sheet that peels or unrolls is the most persuasive argument Paperlab has, and until now the only way to get one out of the editor was a screenshot of the whole application, chrome and all.

Four frames, named for where they go rather than for their arithmetic:

| | | |
|---|---|---|
| **Square** | 1:1 | 1600×1600 |
| **Portrait** | 4:5 — the tallest a feed allows | 1600×2000 |
| **Story** | 9:16 — full screen on a phone | 1080×1920 |
| **Wide** | 16:9 — a slide, a README, a site hero | 1920×1080 |

## Three decisions carry it

**Sized through r3f, not through the renderer.** `gl.setSize` is the obvious call and it is the wrong one: stage mode mounts an `EffectComposer`, which sizes its buffers off r3f's `size` state, so a renderer resized behind its back composites the new frame through an old buffer. `setSize` moves both.

**The app's own loop draws the frame,** rather than a direct `gl.render`. A direct render skips the composer, which for stage mode means exporting an ungraded picture of a scene whose grade is most of how it looks. The rig polls until the drawing buffer is the size it asked for and then waits for a frame drawn at it — polled rather than given a fixed number of frames, because "how many frames is a React commit" is a guess that is only ever wrong on a slow machine, and being wrong means silently capturing at the *old* size, which looks like a working feature that ignores the frame you picked.

**A narrower frame opens the field of view rather than cropping.** A perspective camera holds its vertical field fixed as aspect changes, so exporting a wide viewport to 9:16 quietly cuts the sides off the sheet you just composed — and you would find out from the downloaded file. `fitFov` keeps the horizontal extent that was on screen: an export reveals more above and below, and never less to the left and right. Tested against every frame the menu offers.

Reading the canvas back at all depends on `preserveDrawingBuffer: true`, which the editor's canvas already sets — `captureThumbnail` relies on the same flag.

## Two bugs this turned up in its own first output

- **The grab handle was in the picture.** It is drawn with `depthTest: false` on purpose, so it sits *on top* of the sheet — which makes it the most prominent thing in any captured frame. It is now marked `userData.paperlabChrome` in the library (patch changeset included) and hidden for the duration of a capture. The flag says what the object *is* — an editing affordance rather than artwork — instead of asking every capture path to know one mesh by sight.
- **Every mode named its file after the Paper tab's preset,** so a stage render came out called `receipt-unroll-wide.png`.

## Verification

`lint` · `typecheck` · `knip` clean. **745 tests pass** (11 new, covering `fitFov`'s no-crop guarantee, filename slugging, and degenerate input returning the fov untouched rather than a NaN that blanks the canvas).

Driven in a real browser across all three modes:

- exact pixel sizes out — 1080×1920, 1600×1600, 1920×1080
- the stage's grade survives: bloom, vignette and tone curve all present in the 16:9 render
- no chrome in frame
- the viewport is restored to its own size after every capture
- `pnpm test:share` still passes (the harness clicks the button this renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)