### PR TITLE
Export the motion as a clip

### DIFF
--- a/apps/editor/src/chrome/CaptureRig.tsx
+++ b/apps/editor/src/chrome/CaptureRig.tsx
@@ -2,10 +2,28 @@ import { useThree } from '@react-three/fiber'
 import { useEffect, useRef } from 'react'
 import type { Object3D, PerspectiveCamera } from 'three'
 import { fitFov } from './imageExport'
+import { frameTimes, pickClipFormat } from './videoExport'
+
+export interface ClipRequest {
+  width: number
+  height: number
+  /** How many frames the clip is made of. */
+  frames: number
+  /** Frames per second the clip is paced at. */
+  fps: number
+  /** Out and back, or one way. See `frameTimes`. */
+  style: 'loop' | 'pingpong'
+  /** Put the motion at `t` (0..1). The caller owns this — only it knows the mode. */
+  step(t: number): void
+  /** Reports frames done, for a menu that would otherwise look frozen. */
+  onProgress?(done: number, total: number): void
+}
 
 export interface CaptureHandle {
   /** Render the live scene at an exact pixel size; resolves a PNG data URL. */
   capture(width: number, height: number): Promise<string>
+  /** Step the motion frame by frame and record it. Rejects with a readable reason. */
+  recordClip(request: ClipRequest): Promise<{ blob: Blob; extension: string }>
 }
 
 /**
@@ -39,37 +57,191 @@ export function CaptureRig({ handleRef }: { handleRef: React.RefObject<CaptureHa
   latest.current = state
 
   useEffect(() => {
+    /**
+     * Put the scene into export shape, run `body`, and put it back however
+     * that goes.
+     *
+     * **It resizes the DOM, not the renderer.** Calling r3f's `setSize` is
+     * the obvious move and it does not hold: r3f re-runs a configure block on
+     * every render of `<Canvas>`, and that block measures
+     * `canvas.parentElement` and resets `size` and `dpr` back to what the
+     * container says. Any store write during a capture — and stage mode makes
+     * several, `onQualityChange` among them — silently reverted the export to
+     * viewport size. Sizing the container instead makes r3f's own model agree
+     * with the export, so re-renders re-assert the size we want rather than
+     * fighting it, and the composer and dpr follow for free.
+     *
+     * The container is sized in CSS pixels that come to exactly the requested
+     * DEVICE pixels at the live dpr, so the file is the size that was asked
+     * for on any monitor without touching r3f's dpr at all.
+     *
+     * Restoring is a `finally` and there is one of them rather than one per
+     * caller, because getting it half right is how an export leaves the
+     * viewport 1080×1920 with the grab handle missing.
+     */
+    const framed = async <T,>(width: number, height: number, body: () => Promise<T>): Promise<T> => {
+      const { camera, scene, gl } = latest.current
+      const canvas = gl.domElement as HTMLCanvasElement
+      // Two different elements, and confusing them is what made the first
+      // attempt at this leave the editor stretched. `container` is the
+      // canvas's direct parent, which is the element r3f measures. `panel` is
+      // the editor's own grid track, which is what GROWS when an oversized
+      // canvas sits in it — and a grown track is a container that measures
+      // large, which is a canvas that stays large: a loop that sustains
+      // itself long after the export is over.
+      const container = canvas.parentElement
+      const panel = canvas.closest('.viewport') as HTMLElement | null
+      if (!container || !panel) throw new Error('the canvas is not mounted where it was expected')
+
+      const dpr = latest.current.viewport.dpr || 1
+      const perspective = camera as PerspectiveCamera
+      const fov = perspective.fov
+      // Measured BEFORE anything is touched. The panel is a grid track that
+      // sizes to its contents, so once an oversized canvas has been in it the
+      // track has grown — and measuring on the way out reads the inflated
+      // number and restores the editor to the export's size.
+      const home = container.getBoundingClientRect()
+      const restore = {
+        container: container.getAttribute('style'),
+        panel: panel.getAttribute('style'),
+      }
+      // Editing affordances are not artwork. The grab handle is drawn with
+      // `depthTest: false` so that it sits on top of the sheet, which makes
+      // it the single most prominent thing in an exported picture — a blue
+      // dot in the middle of the receipt you were about to post.
+      const chrome: Object3D[] = []
+      scene.traverse((object) => {
+        if (object.userData.paperlabChrome && object.visible) chrome.push(object)
+      })
+
+      try {
+        for (const object of chrome) object.visible = false
+        perspective.fov = fitFov(fov, canvas.width / canvas.height, width / height)
+        perspective.updateProjectionMatrix()
+        // Out of flow, so an export frame larger than the panel it sits in
+        // does not push the rest of the editor around for the two seconds it
+        // takes; clipped, so it does not paint over the panels either. The
+        // panel is pinned at its own size for the same reason: it is a grid
+        // track that sizes to its contents, and a 1920px canvas in it moves
+        // every other panel on the screen.
+        panel.style.overflow = 'hidden'
+        panel.style.width = `${panel.clientWidth}px`
+        panel.style.height = `${panel.clientHeight}px`
+        container.style.position = 'absolute'
+        container.style.top = '0'
+        container.style.left = '0'
+        container.style.width = `${width / dpr}px`
+        container.style.height = `${height / dpr}px`
+        await drawnAt(width, height)
+        return await body()
+      } finally {
+        for (const object of chrome) object.visible = true
+        perspective.fov = fov
+        perspective.updateProjectionMatrix()
+        // Written back verbatim: these elements are styled by the stylesheet,
+        // and clearing individual properties would leave whatever this set.
+        if (restore.container === null) container.removeAttribute('style')
+        else container.setAttribute('style', restore.container)
+        if (restore.panel === null) panel.removeAttribute('style')
+        else panel.setAttribute('style', restore.panel)
+        // Putting the styles back is not enough. r3f reads the container in a
+        // configure block that runs on RENDER, so with nothing re-rendering
+        // afterwards the editor sat at the export's size with the canvas
+        // hanging over the panels until something else happened to touch
+        // state. Hand it the size the panel had before any of this.
+        // r3f reads the container in a configure block that runs on RENDER,
+        // so with nothing re-rendering afterwards the canvas would keep the
+        // export's size until something unrelated touched state. Hand it the
+        // size the panel had before any of this, and write the canvas's own
+        // inline size back by hand in the same breath so that anything which
+        // re-renders in the next beat — stage mode resumes its walk right
+        // here — measures a panel that is already the right size again.
+        if (home.width > 0 && home.height > 0) await settleBackTo(canvas, home, latest)
+      }
+    }
+
     handleRef.current = {
-      async capture(width: number, height: number) {
-        const { camera, scene, size, setSize, setDpr, viewport } = latest.current
-        const restore = { width: size.width, height: size.height, dpr: viewport.dpr }
-        const perspective = camera as PerspectiveCamera
-        const fov = perspective.fov
-        // Editing affordances are not artwork. The grab handle is drawn with
-        // `depthTest: false` so that it sits on top of the sheet, which makes
-        // it the single most prominent thing in an exported picture — a blue
-        // dot in the middle of the receipt you were about to post.
-        const chrome: Object3D[] = []
-        scene.traverse((object) => {
-          if (object.userData.paperlabChrome && object.visible) chrome.push(object)
-        })
-        try {
-          for (const object of chrome) object.visible = false
-          // Set before the resize: r3f recomputes the projection as part of
-          // handling the new size, so both changes land in one update.
-          perspective.fov = fitFov(fov, size.width / size.height, width / height)
-          // Device pixel ratio is the viewport's business, not the file's —
-          // the requested size IS the pixel size, on any monitor.
-          setDpr(1)
-          setSize(width, height)
-          await drawnAt(width, height)
-          return latest.current.gl.domElement.toDataURL('image/png')
-        } finally {
-          for (const object of chrome) object.visible = true
-          perspective.fov = fov
-          setDpr(restore.dpr)
-          setSize(restore.width, restore.height)
+      capture(width: number, height: number) {
+        return framed(width, height, async () => latest.current.gl.domElement.toDataURL('image/png'))
+      },
+
+      /**
+       * Record the motion by stepping it, not by watching it.
+       *
+       * `captureStream(0)` is a stream with no frame rate of its own and
+       * `requestFrame()` pushes exactly one frame into it, so the app decides
+       * which frames exist. That is what `tools/media.mjs` buys with ffmpeg
+       * and frame-by-frame rendering: no dropped frames and no compositor
+       * jitter, on any machine.
+       *
+       * The loop is PACED to the target frame rate rather than run flat out,
+       * because `MediaRecorder` timestamps frames by wall clock — pushing 72
+       * frames as fast as they render would produce a correct sequence
+       * played at whatever speed the machine happened to manage.
+       */
+      async recordClip({ width, height, frames, fps, style, step, onProgress }) {
+        const canvas = latest.current.gl.domElement as HTMLCanvasElement & {
+          captureStream?(frameRate?: number): MediaStream
         }
+        if (typeof MediaRecorder === 'undefined' || !canvas.captureStream) {
+          throw new Error('this browser cannot record a canvas')
+        }
+        const format = pickClipFormat()
+        if (!format) throw new Error('this browser has no video format it can encode')
+
+        return framed(width, height, async () => {
+          // MediaRecorder locks the clip's dimensions when the stream opens,
+          // so a canvas that has not finished resizing yields a whole clip at
+          // the wrong size — which looks like a working feature that ignores
+          // the frame you picked. Refuse rather than record that.
+          if (canvas.width !== width || canvas.height !== height) {
+            const r3f = latest.current.size
+            throw new Error(
+              `canvas ${canvas.width}×${canvas.height}, r3f ${r3f.width}×${r3f.height}, wanted ${width}×${height}`,
+            )
+          }
+          const stream = canvas.captureStream!(0)
+          const track = stream.getVideoTracks()[0] as MediaStreamTrack & { requestFrame?(): void }
+          // Without it every frame would have to be paced by hope: the stream
+          // would emit on its own schedule and the stepping would be decor.
+          if (!track?.requestFrame) throw new Error('this browser cannot be asked for exact frames')
+
+          const chunks: BlobPart[] = []
+          const recorder = new MediaRecorder(stream, {
+            mimeType: format.mimeType,
+            videoBitsPerSecond: 12_000_000,
+          })
+          recorder.ondataavailable = (e) => {
+            if (e.data.size > 0) chunks.push(e.data)
+          }
+          const finished = new Promise<void>((resolve, reject) => {
+            recorder.onstop = () => resolve()
+            recorder.onerror = () => reject(new Error('the recorder stopped early'))
+          })
+
+          recorder.start()
+          const interval = 1000 / fps
+          const startedAt = performance.now()
+          const times = frameTimes(frames, style)
+          for (let i = 0; i < times.length; i++) {
+            step(times[i]!)
+            // Two frames: one for the step to reach the scene through React
+            // and the deformer stack, one to draw it.
+            await nextFrame()
+            await nextFrame()
+            // Hold until this frame's slot, so the clip plays at `fps`.
+            while (performance.now() - startedAt < i * interval) await nextFrame()
+            track.requestFrame()
+            onProgress?.(i + 1, times.length)
+          }
+          // One slot's worth of tail, so the last frame has a duration rather
+          // than being cut off the moment it is pushed.
+          await new Promise((resolve) => setTimeout(resolve, interval))
+          recorder.stop()
+          await finished
+          for (const t of stream.getTracks()) t.stop()
+          return { blob: new Blob(chunks, { type: format.mimeType }), extension: format.extension }
+        })
       },
     }
     return () => {
@@ -91,6 +263,46 @@ export function CaptureRig({ handleRef }: { handleRef: React.RefObject<CaptureHa
  * you picked. The budget is a ceiling, not a wait: it gives up rather than
  * hanging if a resize is refused (a size past the GPU's limit).
  */
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+/**
+ * Put the canvas back to the size the panel had, and keep putting it back
+ * until it stays.
+ *
+ * One assignment is not enough and neither are two. r3f watches the
+ * container with a ResizeObserver and re-asserts from a `<Canvas>` render on
+ * top of that, so there are two independent writers with notifications
+ * already in flight when an export ends — and whichever of them lands last
+ * wins. A stale 1920 landing after the restore regrows the panel, and a
+ * grown panel measures large, which keeps the canvas large: the loop
+ * sustains itself and the editor never comes back.
+ *
+ * So this is a poll, the same shape as `drawnAt` and for the same reason:
+ * the DOM is the thing that has to agree, and the only way to know it agrees
+ * is to look. It stops once the size has held for several consecutive
+ * frames, and gives up rather than spinning if something else owns the size
+ * for good.
+ */
+async function settleBackTo(
+  canvas: HTMLCanvasElement,
+  home: { width: number; height: number },
+  latest: { current: { setSize(width: number, height: number): void } },
+  budget = 45,
+): Promise<void> {
+  let held = 0
+  for (let i = 0; i < budget && held < 4; i++) {
+    if (Math.abs(canvas.clientWidth - home.width) < 1 && Math.abs(canvas.clientHeight - home.height) < 1) {
+      held++
+    } else {
+      held = 0
+      canvas.style.width = `${home.width}px`
+      canvas.style.height = `${home.height}px`
+      latest.current.setSize(home.width, home.height)
+    }
+    await nextFrame()
+  }
+}
+
 function drawnAt(width: number, height: number, budget = 90): Promise<void> {
   return new Promise((resolve) => {
     let left = budget

--- a/apps/editor/src/chrome/videoExport.test.ts
+++ b/apps/editor/src/chrome/videoExport.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { clipFilename, frameTimes, pickClipFormat } from './videoExport'
+
+describe('pickClipFormat', () => {
+  it('prefers mp4, which is what plays where clips get posted', () => {
+    expect(pickClipFormat(() => true)?.extension).toBe('mp4')
+  })
+
+  it('falls back to webm rather than to nothing', () => {
+    const format = pickClipFormat((m) => m.startsWith('video/webm'))
+    expect(format?.extension).toBe('webm')
+  })
+
+  it('prefers vp9 over vp8 when both are offered', () => {
+    expect(pickClipFormat((m) => m.startsWith('video/webm'))?.mimeType).toContain('vp9')
+  })
+
+  it('returns null where nothing can be recorded, so the caller can say so', () => {
+    expect(pickClipFormat(() => false)).toBeNull()
+  })
+})
+
+describe('frameTimes', () => {
+  it('starts at the beginning of the motion', () => {
+    expect(frameTimes(10, 'loop')[0]).toBe(0)
+    expect(frameTimes(10, 'pingpong')[0]).toBe(0)
+  })
+
+  it('never ends ON the loop point, which would show one frame twice', () => {
+    // A clip whose last frame equals its first stutters once per repeat.
+    expect(frameTimes(10, 'loop').at(-1)).toBeLessThan(1)
+    expect(frameTimes(10, 'pingpong').at(-1)).toBeGreaterThan(0)
+  })
+
+  it('reaches the far end of the motion halfway through a ping-pong', () => {
+    const times = frameTimes(10, 'pingpong')
+    expect(Math.max(...times)).toBeCloseTo(1)
+    expect(times.indexOf(Math.max(...times))).toBe(5)
+  })
+
+  it('comes back the way it went out', () => {
+    // What closes the loop: frame i and frame (count - i) are the same pose.
+    const times = frameTimes(12, 'pingpong')
+    expect(times[1]).toBeCloseTo(times[11]!)
+    expect(times[4]).toBeCloseTo(times[8]!)
+  })
+
+  it('runs one way for a motion that has somewhere to be', () => {
+    const times = frameTimes(8, 'loop')
+    expect(times).toEqual([...times].sort((a, b) => a - b))
+  })
+
+  it('stays inside the motion for every frame it emits', () => {
+    for (const style of ['loop', 'pingpong'] as const) {
+      for (const t of frameTimes(97, style)) {
+        expect(t).toBeGreaterThanOrEqual(0)
+        expect(t).toBeLessThanOrEqual(1)
+      }
+    }
+  })
+
+  it('emits the number of frames it was asked for', () => {
+    expect(frameTimes(72, 'pingpong')).toHaveLength(72)
+    expect(frameTimes(1, 'loop')).toHaveLength(1)
+    // A zero-length clip is a file nobody can play; one frame is the floor.
+    expect(frameTimes(0, 'loop')).toHaveLength(1)
+  })
+})
+
+describe('clipFilename', () => {
+  it('matches the picture export, so a clip and a still sit together', () => {
+    expect(clipFilename('Receipt unroll', 'story', 'mp4')).toBe('receipt-unroll-story.mp4')
+  })
+
+  it('falls back rather than producing a dotfile', () => {
+    expect(clipFilename('  ', 'square', 'webm')).toBe('paper-square.webm')
+  })
+})

--- a/apps/editor/src/chrome/videoExport.ts
+++ b/apps/editor/src/chrome/videoExport.ts
@@ -1,0 +1,88 @@
+/**
+ * Exporting the motion as a clip.
+ *
+ * `tools/media.mjs` already records the README's assets, and its opening
+ * comment is the specification for this: it steps the motion one exact frame
+ * at a time rather than screen-recording it, "so the loop is deterministic:
+ * no dropped frames, no compositor jitter, identical output on any machine."
+ * That is the guarantee worth carrying into the browser, because the thing
+ * being sold is motion and a clip with a hitch in it argues against the
+ * product.
+ *
+ * The browser has no ffmpeg, but it has the same trick in a different shape:
+ * `canvas.captureStream(0)` produces a stream with no frame rate of its own,
+ * and `requestFrame()` pushes exactly one frame into it. So the app decides
+ * which frames exist and `MediaRecorder` does the encoding — deterministic
+ * stepping with no encoder, muxer or dependency to ship.
+ */
+
+export interface ClipFormat {
+  mimeType: string
+  extension: string
+}
+
+/**
+ * The best container this browser will actually encode, in preference order.
+ *
+ * MP4 first because it is the one that plays everywhere a clip gets posted —
+ * a WebM dropped into a DM is a file the recipient cannot open on a phone.
+ * WebM is the fallback because for years it was the only thing Chrome would
+ * record, and a clip in a format someone has to convert still beats no clip.
+ */
+const CANDIDATES: ClipFormat[] = [
+  { mimeType: 'video/mp4;codecs=avc1.42E01E', extension: 'mp4' },
+  { mimeType: 'video/mp4', extension: 'mp4' },
+  { mimeType: 'video/webm;codecs=vp9', extension: 'webm' },
+  { mimeType: 'video/webm;codecs=vp8', extension: 'webm' },
+  { mimeType: 'video/webm', extension: 'webm' },
+]
+
+export function pickClipFormat(
+  isSupported: (mimeType: string) => boolean = (m) =>
+    typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(m),
+): ClipFormat | null {
+  return CANDIDATES.find((candidate) => isSupported(candidate.mimeType)) ?? null
+}
+
+/**
+ * Where the motion sits at each frame of the clip.
+ *
+ * `pingpong` runs the motion out and back, so the loop closes without a jump
+ * cut — a peel that snaps flat every 2.4 seconds reads as a broken GIF, not
+ * as a peel. `loop` runs 0→1 for motion that already arrives where it
+ * started, or that has somewhere to be: a walk played backwards is a person
+ * walking backwards.
+ *
+ * Neither ends ON 1. The last frame is the one BEFORE the loop point, since
+ * a clip that ends where it begins shows that frame twice and stutters once
+ * per repeat.
+ */
+export function frameTimes(count: number, style: 'loop' | 'pingpong'): number[] {
+  const frames = Math.max(1, Math.floor(count))
+  return Array.from({ length: frames }, (_, i) => {
+    const u = i / frames
+    if (style === 'loop') return u
+    return u < 0.5 ? u * 2 : 2 - u * 2
+  })
+}
+
+export function clipFilename(name: string, frameId: string, extension: string): string {
+  const slug =
+    name
+      .trim()
+      .replace(/[^a-zA-Z0-9-_]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase() || 'paper'
+  return `${slug}-${frameId}.${extension}`
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  // Revoked on a later turn of the loop: revoking synchronously can beat the
+  // browser to the download it was handed.
+  setTimeout(() => URL.revokeObjectURL(url), 10_000)
+}

--- a/apps/editor/src/panels/ExportMenu.tsx
+++ b/apps/editor/src/panels/ExportMenu.tsx
@@ -18,7 +18,13 @@ import {
 } from 'paperlab/stage'
 import type { CaptureHandle } from '../chrome/CaptureRig'
 import { EXPORT_FRAMES, downloadImage, imageFilename } from '../chrome/imageExport'
+import { clipFilename, downloadBlob } from '../chrome/videoExport'
 import { toast } from '../controls/ui'
+import { useEditor } from '../state/store'
+
+/** 2.4 seconds at 30fps — long enough to read a motion, short enough to loop. */
+const CLIP_FRAMES = 72
+const CLIP_FPS = 30
 /**
  * Two ways out of the editor, and they are for different people.
  *
@@ -52,7 +58,11 @@ export function ExportMenu({
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState<string | null>(null)
   const [rendering, setRendering] = useState<string | null>(null)
+  const [recording, setRecording] = useState<{ id: string; done: number } | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
+  const patchStage = useEditor((s) => s.patchStage)
+  const stagePlaying = useEditor((s) => s.stage.playing)
+  const busy = rendering !== null || recording !== null
 
   useEffect(() => {
     if (!open) return
@@ -76,6 +86,87 @@ export function ExportMenu({
 
   const badge = (label: string) => (copied === label ? <span className="copied-badge">Copied ✓</span> : null)
 
+  // Named for what is IN the picture. Field and Stage are compositions of
+  // their own, and both were coming out named after whichever paper the
+  // Paper tab happened to be holding.
+  const subject = mode === 'paper' ? config.meta.name : mode
+
+  /**
+   * What drives the motion while a clip records, and how to put things back.
+   *
+   * Supplied per mode rather than discovered by the rig, because only this
+   * component knows what "the motion" is: a behavior's progress in Paper
+   * mode, distance along the walk in Stage. Field has neither — its motion
+   * runs on its own clock with nothing to step — so it returns null and the
+   * menu says why instead of offering a button that cannot work.
+   *
+   * Whatever was playing is paused first. A clock still running underneath
+   * would be a second animation fighting the stepping, and the recorded
+   * frames would come out of the argument between them.
+   */
+  const clipDriver = () => {
+    if (mode === 'paper') {
+      const handle = paperRef.current
+      if (!handle || !config.behavior) return null
+      const wasPlaying = handle.playing
+      return {
+        // Out and back, so the loop closes: a peel that snaps flat every
+        // 2.4 seconds reads as a broken GIF rather than as a peel.
+        style: 'pingpong' as const,
+        step: (t: number) => handle.set('progress', t),
+        before: () => handle.pause(),
+        after: () => {
+          if (wasPlaying) handle.play()
+        },
+      }
+    }
+    if (mode === 'stage') {
+      return {
+        // One way. A walk played backwards is a person walking backwards.
+        style: 'loop' as const,
+        step: (t: number) => patchStage({ progress: t }),
+        before: () => patchStage({ playing: false }),
+        after: () => patchStage({ playing: stagePlaying }),
+      }
+    }
+    return null
+  }
+
+  /** Why there is no clip to record, or null when there is. */
+  const clipBlocker = (): string | null => {
+    if (mode === 'field') return 'Field motion runs on its own clock — there is no timeline to step.'
+    if (mode === 'paper' && !config.behavior)
+      return 'Pick a behavior first — a still sheet has no motion to record.'
+    return null
+  }
+
+  const saveClip = async (frame: (typeof EXPORT_FRAMES)[number]) => {
+    const capture = captureRef.current
+    const driver = clipDriver()
+    if (!capture || !driver) return
+    setRecording({ id: frame.id, done: 0 })
+    driver.before()
+    try {
+      const { blob, extension } = await capture.recordClip({
+        width: frame.width,
+        height: frame.height,
+        frames: CLIP_FRAMES,
+        fps: CLIP_FPS,
+        style: driver.style,
+        step: driver.step,
+        onProgress: (done) => setRecording({ id: frame.id, done }),
+      })
+      downloadBlob(blob, clipFilename(subject, frame.id, extension))
+    } catch (error) {
+      // A browser with no recorder, no codec, or no exact-frame control. All
+      // three are better named than silently doing nothing.
+      toast(`Could not record that clip: ${error instanceof Error ? error.message : error}`, 'error')
+    } finally {
+      driver.after()
+      setRecording(null)
+    }
+  }
+
   const saveImage = async (frame: (typeof EXPORT_FRAMES)[number]) => {
     const capture = captureRef.current
     if (!capture) return
@@ -85,7 +176,7 @@ export function ExportMenu({
       // Named for what is IN the picture. Field and Stage are compositions of
       // their own, and both were coming out named after whichever paper the
       // Paper tab happened to be holding.
-      downloadImage(dataUrl, imageFilename(mode === 'paper' ? config.meta.name : mode, frame.id))
+      downloadImage(dataUrl, imageFilename(subject, frame.id))
       // The menu stays open — picking a second frame is the common next move,
       // and the download itself is the confirmation.
     } catch (error) {
@@ -125,17 +216,29 @@ export function ExportMenu({
           <p className="export-group">Picture</p>
           <div className="export-frames">
             {EXPORT_FRAMES.map((frame) => (
-              <button
-                key={frame.id}
-                type="button"
-                disabled={rendering !== null}
-                onClick={() => void saveImage(frame)}
-              >
+              <button key={frame.id} type="button" disabled={busy} onClick={() => void saveImage(frame)}>
                 <strong>{frame.label}</strong>
                 <span>{rendering === frame.id ? 'rendering…' : frame.hint}</span>
               </button>
             ))}
           </div>
+          <p className="export-group">Clip</p>
+          {clipBlocker() ? (
+            <p className="export-note">{clipBlocker()}</p>
+          ) : (
+            <div className="export-frames">
+              {EXPORT_FRAMES.map((frame) => (
+                <button key={frame.id} type="button" disabled={busy} onClick={() => void saveClip(frame)}>
+                  <strong>{frame.label}</strong>
+                  <span>
+                    {recording?.id === frame.id
+                      ? `recording ${Math.round((recording.done / CLIP_FRAMES) * 100)}%`
+                      : `${(CLIP_FRAMES / CLIP_FPS).toFixed(1)}s loop`}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
           <p className="export-group">Code</p>
           {mode === 'stage' ? (
             <>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -469,6 +469,16 @@ button.export:hover {
   background: var(--l3);
 }
 
+/* Why a section is empty, where the buttons would have been. A disabled row
+   says "not now"; this has to say "not here, and here is what would make it
+   possible", which needs a sentence. */
+.export-dropdown .export-note {
+  color: var(--ink-body);
+  font-size: 11px;
+  line-height: 1.45;
+  padding: 2px 14px 10px;
+}
+
 /* "Copy for AI" is the hero path — promote it over the secondary two. */
 .export-dropdown .export-primary {
   position: relative;


### PR DESCRIPTION
Stacked on #55 → #54 → #53 → #52.

`tools/media.mjs` already records the README's assets, and its opening comment is the spec: it steps the motion one exact frame at a time rather than screen-recording it, *"so the loop is deterministic: no dropped frames, no compositor jitter, identical output on any machine."* That guarantee is worth carrying into the browser, because the thing being sold **is** motion and a clip with a hitch in it argues against the product.

## How, with no ffmpeg

`canvas.captureStream(0)` gives a stream with no frame rate of its own, and `requestFrame()` pushes exactly one frame into it. So the app decides which frames exist and `MediaRecorder` does the encoding — deterministic stepping, no encoder, no muxer, no dependency.

The loop is **paced** to the target frame rate rather than run flat out, because `MediaRecorder` timestamps frames by wall clock: pushing 72 frames as fast as they render would give a correct sequence played at whatever speed the machine happened to manage.

| mode | timeline | style |
|---|---|---|
| Paper | behavior progress | ping-pong — a peel that snaps flat every 2.4s reads as a broken GIF, not a peel |
| Stage | distance along the walk | one way — a walk played backwards is a person walking backwards |
| Field | none | the section says so, instead of offering a button that cannot work |

## The hard part was not the recording

**Sizing by calling r3f's `setSize` does not hold.** r3f re-runs a configure block on every render of `<Canvas>` that measures `canvas.parentElement` and resets `size` and `dpr` back to what the container says. Stage mode writes to the store several times a second — the walk, `onQualityChange` — so every one of those silently reverted the export to viewport size. Sizing the **container** instead makes r3f's own model agree with the export, and the composer and dpr follow for free.

**Coming back was harder, and cost three wrong fixes worth recording:**

1. The editor's `.viewport` is a grid track that grows to fit an oversized canvas — and a grown track measures large, which keeps the canvas large. The loop sustains itself long after the export ends. Pinning the track stops it starting. (My first attempt pinned r3f's own div instead, having misread the DOM chain.)
2. Measuring the home size on the way *out* reads the already-inflated number. It has to be taken before anything is touched.
3. A single restore loses to a ResizeObserver notification for the export size that is still in flight. So the restore is a **poll** that re-asserts until the size holds for several consecutive frames — the same shape as `drawnAt`, for the same reason: the DOM is what has to agree, and the only way to know it agrees is to look.

**That last one was a latent bug in the image export from #53 too.** It passed its tests by luck of timing rather than by being right, and would have failed for a user whenever a re-render landed mid-capture. Fixed here for both paths.

## Verification

`lint` · `typecheck` · `knip` clean. **771 tests pass** (13 new on the clip timeline: never ending on the loop point, reaching the far end at the midpoint of a ping-pong, coming back the way it went out, mp4 preferred over webm, and null where nothing can be encoded so the caller can say so). `pnpm test:share` still passes.

Driven in a browser across every combination:

```
Paper  still  receipt-unroll-story.png  png,1080,1920      viewport 964x844
Paper  clip   receipt-unroll-wide.mp4   h264,1920,1080,72  viewport 964x844
Field  still  field-square.png          png,1600,1600      viewport 964x844
Stage  still  stage-story.png           png,1080,1920      viewport 964x844
Stage  clip   stage-wide.mp4            h264,1920,1080,72  viewport 964x844
```

Exact sizes, exactly 72 frames, viewport restored every time, no console errors. Frames pulled back out of the clip show the receipt rolled at 0, half-unrolled at 18 and fully unrolled at the ping-pong's midpoint — with no grab handle in any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)