### PR TITLE
Colour pickers, the light panel everywhere, and the backdrop

### DIFF
--- a/.changeset/a-colour-is-not-a-string.md
+++ b/.changeset/a-colour-is-not-a-string.md
@@ -1,0 +1,14 @@
+---
+'paperlab': minor
+---
+
+Mark every colour field with `.describe('color')`, and publish `sceneSchema`.
+
+A colour is a string the way a date is a string, and a schema-driven panel had
+no way to tell the difference — so twelve colour fields across content, wash,
+light and the stage rendered as text boxes you had to type hex into. The schema
+now says which strings are pigments, rather than asking every consumer to guess
+from field names: `color` and `secondary` are both colours, `font` and `text`
+are both not, and no rule over names separates them.
+
+`sceneSchema` becomes public because `<PaperField>` now takes one.

--- a/.changeset/one-light-panel-not-three.md
+++ b/.changeset/one-light-panel-not-three.md
@@ -1,0 +1,29 @@
+---
+'paperlab': minor
+---
+
+Light overrides reach a single sheet and a field, not just a stage.
+
+`scene.light` joins `scene.lighting`, so a `<Paper>` can be "studio, but the
+key is lower and the room is dimmer" — the authorable half that stage mode has
+always had. `<PaperLighting>` has accepted these overrides all along; nothing
+was passing them, and a lone sheet could only ever be one of seven rigs exactly
+as shipped.
+
+`lightSchema` moves from `scene/lighting.ts` into `config/schema.ts`, where the
+rest of the serialized config lives. It has to: `sceneSchema` needs it, and
+`lighting.ts` imports FROM the schema, so the dependency could not run the
+other way. It is re-exported from its old home, where a caller reaching for the
+overrides beside `resolveLighting` will still find it.
+
+`<PaperField>` takes a `scene` too, and lights itself with `<PaperLighting>`
+rather than the bare ambient-and-directional pair it had. **This changes how an
+existing `<PaperField>` looks** — and it changes it to what the editor has been
+showing all along, which is the point: the gallery you composed and the gallery
+the exported code produced were lit by two different rigs, and the export was
+the one nobody had looked at.
+
+`diffFieldProps` also now compares structurally rather than by reference. No
+object or array copied from a default is ever reference-equal to it, so a
+layout option holding an array exported a prop that said exactly what the
+default already said.

--- a/.changeset/the-scene-survives-the-trip-out.md
+++ b/.changeset/the-scene-survives-the-trip-out.md
@@ -1,0 +1,22 @@
+---
+'paperlab': patch
+---
+
+Fix `diffConfig` throwing away everything in a scene except `lighting`.
+
+It read `if (config.scene.lighting !== 'studio') out.scene = { lighting }`,
+which was true while `lighting` was the only thing a scene had — and silently
+discarded every field added beside it. So a hand-tuned light rig, and now a
+backdrop, were shown by the editor and carried by nothing that left it: not a
+`.paper` file, not a share link, not a JSX snippet or an agent payload.
+
+The scene is diffed like every other branch of the config now, and a test
+round-trips it: what the diff emits parses back to what went in.
+
+Code exports also stop pasting uploaded pictures into source. An upload is a
+data URL of a hundred kilobytes and up, and there are two places one can now
+be — the sheet's content and the backdrop behind it. A snippet gets a numbered
+path in the same position and a line saying so; a referenced URL is untouched.
+The `.paper` file and the share link still carry the real bytes, because a file
+has room for them and dropping them there would lose the artwork rather than
+reformat it.

--- a/.changeset/what-is-behind-the-sheet.md
+++ b/.changeset/what-is-behind-the-sheet.md
@@ -1,0 +1,25 @@
+---
+'paperlab': minor
+---
+
+Backdrops: `scene.backdrop`, and `<PaperBackdrop>` to render one.
+
+A colour and a picture behind the sheet, with `fade` and `blur` so the
+backdrop stays a backdrop — a photograph at full strength competes with the
+paper in front of it, which is what a photographer solves by putting the
+background out of the light.
+
+Optional on purpose. An unset backdrop leaves the canvas exactly as it was
+found, because `<Paper>` has always rendered onto whatever is behind it and a
+default that painted the frame would change the look of every sheet already on
+a page.
+
+Painted onto a canvas at the viewport's size rather than assigned straight to
+`scene.background`: three stretches a background texture to the frame whatever
+shape it is, so a landscape photograph behind a 9:16 export would come out
+squashed — and the export sizes are exactly where a backdrop earns its keep.
+
+`<Paper>` and `<PaperField>` render it. `<PaperMesh>` deliberately does not —
+it drops into someone else's scene, and a sheet that repainted the background
+of the app it is embedded in would be doing something nobody asked for.
+Callers who own their own canvas render `<PaperBackdrop>` themselves.

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -3,6 +3,7 @@ import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Stats } from '@react-three/drei'
 import {
   PaperFieldMesh,
+  PaperBackdrop,
   PaperLighting,
   PaperMesh,
   diffConfig,
@@ -408,6 +409,12 @@ export function App() {
               here shifts the perceived colour of the paper sitting in front
               of it — see `docs/design.md`, amendment 2. */}
           <color attach="background" args={[mode === 'stage' ? '#0b0b0b' : '#171717']} />
+          {/* The editor owns this canvas, so it renders the backdrop itself —
+              the same way it renders the lighting rig. Stage has a whole
+              room of its own and would be arguing with one. */}
+          {mode !== 'stage' && (
+            <PaperBackdrop backdrop={mode === 'paper' ? config.scene.backdrop : fieldScene.backdrop} />
+          )}
           {/* Stage brings its own rig — a second one here would double the key. */}
           {mode !== 'stage' && (
             <PaperLighting

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -7,6 +7,7 @@ import {
   PaperMesh,
   diffConfig,
   getPreset,
+  sceneSchema,
   isBuiltinPreset,
   listPresets,
   resolveStateConfig,
@@ -166,7 +167,10 @@ export function App() {
     }
   })
   const fieldZones = field.zones.map(zoneToConfig)
+  const fieldScene = sceneSchema.parse(field.scene)
+
   const fieldExportInput = (): FieldExportInput => ({
+    scene: field.scene,
     layout: field.layout,
     layoutOptions: field.layoutOptions,
     motion: { driver: field.driver, speed: field.speed },
@@ -407,11 +411,11 @@ export function App() {
           {/* Stage brings its own rig — a second one here would double the key. */}
           {mode !== 'stage' && (
             <PaperLighting
-              preset={
-                mode === 'paper'
-                  ? config.scene.lighting
-                  : resolvePresetByName(field.slots[0] ?? 'photo-print').scene.lighting
-              }
+              // Field mode used to inherit slot 0's preset, so swapping one
+              // card changed the lighting of the whole gallery. It has its
+              // own scene now, the same one the export carries.
+              preset={mode === 'paper' ? config.scene.lighting : fieldScene.lighting}
+              light={mode === 'paper' ? config.scene.light : fieldScene.light}
               floor={mode === 'paper' ? -1.5 : -2.4}
               scale={mode === 'paper' ? 10 : 14}
             />

--- a/apps/editor/src/controls/controlModel.test.ts
+++ b/apps/editor/src/controls/controlModel.test.ts
@@ -269,3 +269,61 @@ describe('numericFields', () => {
     expect(numericFields(z.number())).toEqual([])
   })
 })
+
+describe('colours', () => {
+  it('draws a described string as a swatch, not a text field', () => {
+    const schema = z.object({ color: z.string().describe('color').default('#4a5b8c') })
+    expect(
+      byKey(
+        schemaControls(schema, { color: '#123456' }, () => {}),
+        'color',
+      ),
+    ).toMatchObject({
+      kind: 'color',
+      value: '#123456',
+    })
+  })
+
+  it('finds the marker after .default(), where zod actually puts it', () => {
+    // `.describe()` attaches to whatever it was called on, so this lands on
+    // the ZodDefault and never reaches the string the walk unwraps to.
+    const schema = z.object({ color: z.string().default('#4a5b8c').describe('color') })
+    expect(
+      byKey(
+        schemaControls(schema, {}, () => {}),
+        'color',
+      ).kind,
+    ).toBe('color')
+  })
+
+  it('finds it after .optional() too — the light rig is written that way', () => {
+    const schema = z.object({ color: z.string().optional().describe('color') })
+    expect(
+      byKey(
+        schemaControls(schema, {}, () => {}),
+        'color',
+      ).kind,
+    ).toBe('color')
+  })
+
+  it('leaves every other string alone', () => {
+    // `color` and `secondary` are both pigments and `font` and `text` are
+    // both not; no rule over field NAMES separates them, which is why the
+    // schema says so instead.
+    const schema = z.object({ font: z.string().default('Georgia'), text: z.string().default('hi') })
+    const controls = schemaControls(schema, {}, () => {})
+    expect(controls.map((c) => c.kind)).toEqual(['text', 'text'])
+  })
+
+  it('writes the value straight through, so a paste survives', () => {
+    const seen: string[] = []
+    const schema = z.object({ color: z.string().describe('color').default('#000000') })
+    const ctl = byKey(
+      schemaControls(schema, {}, (_k, v) => seen.push(v as string)),
+      'color',
+    )
+    if (ctl.kind !== 'color') throw new Error('expected color')
+    ctl.onChange('#ff8800')
+    expect(seen).toEqual(['#ff8800'])
+  })
+})

--- a/apps/editor/src/controls/controlModel.ts
+++ b/apps/editor/src/controls/controlModel.ts
@@ -38,6 +38,14 @@ export type Control =
       onChange: (v: boolean) => void
     }
   | {
+      kind: 'color'
+      key: string
+      label: string
+      /** Whatever the config holds — may not be a `#rrggbb` the swatch can show. */
+      value: string
+      onChange: (v: string) => void
+    }
+  | {
       kind: 'text'
       key: string
       label: string
@@ -109,6 +117,13 @@ export const text = (
   onChange,
 })
 
+export const color = (
+  key: string,
+  value: string,
+  onChange: (v: string) => void,
+  label?: string,
+): Control => ({ kind: 'color', key, label: label ?? key, value, onChange })
+
 export const note = (key: string, value: string): Control => ({ kind: 'note', key, value })
 
 export const button = (label: string, onClick: () => void, key?: string): Control => ({
@@ -177,6 +192,15 @@ export function partitionSignature(
   }
 }
 
+/**
+ * What a schema field says about itself to be drawn as a colour.
+ *
+ * Kept next to the walk that reads it rather than exported from the library,
+ * because it is a contract about a STRING and the library's half of it is a
+ * single call. `paperlab` marks the field; this decides what to draw.
+ */
+const COLOR = 'color'
+
 // ── The schema walk. ────────────────────────────────────────────────────────
 
 /**
@@ -231,7 +255,20 @@ export function schemaControls(
     } else if (inner instanceof z.ZodBoolean) {
       controls.push(toggle(key, Boolean(value), (v) => onChange(key, v)))
     } else if (inner instanceof z.ZodString) {
-      controls.push(text(key, String(value ?? ''), (v) => onChange(key, v)))
+      // A colour is a string the way a date is a string. The schema says
+      // which ones with `.describe('color')`, rather than this walk guessing
+      // from field names — `color` and `secondary` are both pigments, and
+      // `font` and `text` are both not, and no naming rule separates them.
+      //
+      // Read off BOTH the field and its unwrapped inside, because
+      // `.describe()` attaches to whatever it was called on: after
+      // `.default()` it lands on the ZodDefault and never reaches the string.
+      const described = field.description ?? inner.description
+      controls.push(
+        described === COLOR
+          ? color(key, String(value ?? ''), (v) => onChange(key, v))
+          : text(key, String(value ?? ''), (v) => onChange(key, v)),
+      )
     } else if (inner instanceof z.ZodObject) {
       const nested = (value ?? {}) as Record<string, unknown>
       const children = schemaControls(inner, nested, (childKey, childValue) =>

--- a/apps/editor/src/controls/controls.tsx
+++ b/apps/editor/src/controls/controls.tsx
@@ -32,6 +32,8 @@ function ControlRow({ control }: { control: Control }) {
       return <SelectControl control={control} />
     case 'toggle':
       return <ToggleControl control={control} />
+    case 'color':
+      return <ColorControl control={control} />
     case 'text':
       return <TextControl control={control} />
     case 'note':
@@ -221,6 +223,118 @@ function ToggleControl({ control }: { control: Of<'toggle'> }) {
         />
         <span className="control-toggle-track" aria-hidden="true" />
       </label>
+    </div>
+  )
+}
+
+/** `#rgb` and `#rrggbb`, the two a swatch can show. */
+const HEX = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i
+
+/** What the swatch shows for a value it cannot parse. */
+const expand = (value: string): string => {
+  const v = value.trim()
+  if (!HEX.test(v)) return '#000000'
+  return v.length === 4 ? `#${v[1]}${v[1]}${v[2]}${v[2]}${v[3]}${v[3]}` : v
+}
+
+/**
+ * A real colour picker, and the hex beside it.
+ *
+ * Both, rather than either. The swatch is how you find a colour you have not
+ * decided on yet; the field is how you paste the one from your brand
+ * palette, and how you read back what the swatch gave you.
+ *
+ * **The swatch is throttled.** A native picker fires while you drag it, and
+ * on a content colour every one of those events repaints the sheet's texture
+ * — the same cost that made text commit on blur rather than per keystroke.
+ * Dropping the events would make the picker feel dead, so they are spent at
+ * a rate a canvas can keep up with, and the value you release on is always
+ * committed whether or not it lands on a tick.
+ */
+function ColorControl({ control }: { control: Of<'color'> }) {
+  const { value, onChange } = control
+  const [draft, setDraft] = useState(value)
+  const committed = useRef(value)
+  const throttle = useRef<{ at: number; pending: string | null; timer: number | null }>({
+    at: 0,
+    pending: null,
+    timer: null,
+  })
+
+  if (committed.current !== value) {
+    committed.current = value
+    if (draft !== value) setDraft(value)
+  }
+
+  // Cleared on unmount so a trailing commit cannot fire into a dead control.
+  useEffect(() => {
+    const state = throttle.current
+    return () => {
+      if (state.timer !== null) window.clearTimeout(state.timer)
+    }
+  }, [])
+
+  const RATE = 120
+
+  const live = (next: string) => {
+    setDraft(next)
+    const state = throttle.current
+    const now = performance.now()
+    if (now - state.at >= RATE) {
+      state.at = now
+      committed.current = next
+      onChange(next)
+      return
+    }
+    // Not this tick — but never dropped: the last value seen wins at the end.
+    state.pending = next
+    if (state.timer === null) {
+      state.timer = window.setTimeout(
+        () => {
+          state.timer = null
+          state.at = performance.now()
+          if (state.pending !== null) {
+            committed.current = state.pending
+            onChange(state.pending)
+            state.pending = null
+          }
+        },
+        RATE - (now - state.at),
+      )
+    }
+  }
+
+  const commitText = () => {
+    if (draft !== value) {
+      committed.current = draft
+      onChange(draft)
+    }
+  }
+
+  return (
+    <div className="control-row">
+      <span className="control-label">{control.label}</span>
+      <div className="control-color">
+        <input
+          type="color"
+          value={expand(draft)}
+          aria-label={`${control.label} swatch`}
+          onChange={(e) => live(e.target.value)}
+        />
+        <input
+          type="text"
+          className="control-text"
+          value={draft}
+          aria-label={control.label}
+          spellCheck={false}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitText}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+            if (e.key === 'Escape') setDraft(value)
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/editor/src/panels/FieldInspector.tsx
+++ b/apps/editor/src/panels/FieldInspector.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { getLayout, listLayouts, listPresets } from 'paperlab'
+import { getLayout, listLayouts, listPresets, sceneSchema } from 'paperlab'
 import {
   button,
   folder,
@@ -11,6 +11,7 @@ import {
   type Control,
 } from '../controls/controlModel'
 import { Panel } from '../controls/controls'
+import { lightControls } from './lightControls'
 import { useEditor, type EditorZone } from '../state/store'
 
 /**
@@ -72,6 +73,19 @@ export function FieldInspector() {
         select('replaceWith', replaceTarget, listPresets(), setReplaceTarget, 'replace all with'),
         button('Replace all →', () => setAllSlots(replaceTarget)),
       ],
+      { collapsed: true },
+    ),
+    // The same light panel paper and stage have. A gallery used to be lit by
+    // whichever preset happened to be in slot 0, so swapping one card
+    // relit the room.
+    folder(
+      'Light',
+      // Parsed, not passed raw. The panel draws the RESOLVED rig — the
+      // numbers the scene is actually using — and a half-filled scene has no
+      // preset name for it to resolve against.
+      lightControls(sceneSchema.parse(field.scene) as unknown as Record<string, unknown>, (patch) =>
+        patchField({ scene: { ...field.scene, ...(patch as object) } }),
+      ),
       { collapsed: true },
     ),
     folder(

--- a/apps/editor/src/panels/FieldInspector.tsx
+++ b/apps/editor/src/panels/FieldInspector.tsx
@@ -12,6 +12,7 @@ import {
 } from '../controls/controlModel'
 import { Panel } from '../controls/controls'
 import { lightControls } from './lightControls'
+import { backdropControls } from './backdropControls'
 import { useEditor, type EditorZone } from '../state/store'
 
 /**
@@ -85,6 +86,13 @@ export function FieldInspector() {
       // preset name for it to resolve against.
       lightControls(sceneSchema.parse(field.scene) as unknown as Record<string, unknown>, (patch) =>
         patchField({ scene: { ...field.scene, ...(patch as object) } }),
+      ),
+      { collapsed: true },
+    ),
+    folder(
+      'Scene',
+      backdropControls(sceneSchema.parse(field.scene).backdrop, (next) =>
+        patchField({ scene: { ...field.scene, backdrop: next } }),
       ),
       { collapsed: true },
     ),

--- a/apps/editor/src/panels/Inspector.tsx
+++ b/apps/editor/src/panels/Inspector.tsx
@@ -3,7 +3,6 @@ import {
   contentSchemaFor,
   getBehavior,
   getStock,
-  lightingNames,
   listBehaviors,
   paperEdges,
   physicsNames,
@@ -35,6 +34,7 @@ import { Panel } from '../controls/controls'
 import { useEditor } from '../state/store'
 import { formatItems, parseItems } from './receiptItems'
 import { pickImageAsDataUrl } from '../chrome/pickImage'
+import { lightControls } from './lightControls'
 
 /**
  * Inspector of the selection: a tree of `Control` descriptors rendered by the
@@ -105,13 +105,14 @@ export function Inspector() {
     folder('Content', contentControls(config.content, patchConfig), { collapsed: true }),
     folder('Surface', surfaceControls(config.surface, config.stock, setSurface), { collapsed: true }),
     folder('Physics', physicsControls(config.physics, setPhysics, patchCloth), { collapsed: true }),
+    // The same light panel stage mode has always had. It was never a stage
+    // feature — `<PaperLighting>` has taken these overrides all along, and a
+    // lone sheet simply had no control that wrote them.
     folder(
-      'Scene',
-      [
-        select('lighting', config.scene.lighting, [...lightingNames], (v) =>
-          patchConfig({ scene: { lighting: v as never } }),
-        ),
-      ],
+      'Light',
+      lightControls(config.scene as unknown as Record<string, unknown>, (patch) =>
+        patchConfig({ scene: patch as never }),
+      ),
       { collapsed: true },
     ),
   ]

--- a/apps/editor/src/panels/Inspector.tsx
+++ b/apps/editor/src/panels/Inspector.tsx
@@ -35,6 +35,7 @@ import { useEditor } from '../state/store'
 import { formatItems, parseItems } from './receiptItems'
 import { pickImageAsDataUrl } from '../chrome/pickImage'
 import { lightControls } from './lightControls'
+import { backdropControls } from './backdropControls'
 
 /**
  * Inspector of the selection: a tree of `Control` descriptors rendered by the
@@ -112,6 +113,13 @@ export function Inspector() {
       'Light',
       lightControls(config.scene as unknown as Record<string, unknown>, (patch) =>
         patchConfig({ scene: patch as never }),
+      ),
+      { collapsed: true },
+    ),
+    folder(
+      'Scene',
+      backdropControls(config.scene.backdrop, (next, opts) =>
+        patchConfig({ scene: { backdrop: next } as never }, opts),
       ),
       { collapsed: true },
     ),

--- a/apps/editor/src/panels/StageInspector.tsx
+++ b/apps/editor/src/panels/StageInspector.tsx
@@ -1,20 +1,10 @@
-import {
-  getLayout,
-  lightAngles,
-  lightSchema,
-  lightingNames,
-  listLayouts,
-  resolveLighting,
-  type LightOverrides,
-  type LightingName,
-} from 'paperlab'
+import { getLayout, listLayouts } from 'paperlab'
 import { qualityNames, stageBanner, stageSchema, walkNames } from 'paperlab/stage'
 import {
   button,
   folder,
   note,
   num,
-  numberRange,
   schemaControls,
   select,
   text,
@@ -23,6 +13,7 @@ import {
 import { Panel } from '../controls/controls'
 import { useEditor, type StageState } from '../state/store'
 import { pickImagesAsDataUrls } from '../chrome/pickImage'
+import { lightControls } from './lightControls'
 
 /**
  * Stage mode inspector: Content / Walk / Arrangement / Light / Stage /
@@ -185,45 +176,4 @@ function contentControls(stage: StageState, patchStage: (patch: Partial<StageSta
   )
 
   return controls
-}
-
-/**
- * The light panel, built by hand for one reason: every field is an OVERRIDE.
- *
- * A generated slider reads its value out of the config, and an unset
- * override has none — the whole point is that it means "whatever the preset
- * says". So the sliders show the RESOLVED rig, which is the number the
- * scene is actually using, and touching one writes that field and only that
- * field. Reset drops the overrides and hands the look back to the preset.
- *
- * Direction and height are the same two angles Blender's light panel asks
- * for rather than a position vector, because "where is the light" is a
- * question about the room and not about the coordinate system.
- */
-function lightControls(
-  values: Record<string, unknown>,
-  patch: (patch: Record<string, unknown>) => void,
-): Control[] {
-  const preset = values.lighting as LightingName
-  const light = (values.light ?? {}) as LightOverrides
-  const rig = resolveLighting(preset, light)
-  const angles = lightAngles(rig.key.position)
-  const set = (key: keyof LightOverrides, value: unknown) => patch({ light: { ...light, [key]: value } })
-  const range = (key: keyof LightOverrides) => numberRange(lightSchema, key)
-  const touched = Object.values(light).some((v) => v !== undefined)
-
-  return [
-    select('preset', preset, [...lightingNames], (v) => patch({ lighting: v })),
-    num('exposure', rig.exposure, range('exposure'), (v) => set('exposure', v)),
-    num('key', rig.key.intensity, range('key'), (v) => set('key', v)),
-    text('color', rig.key.color, (v) => set('color', v)),
-    num('direction', angles.azimuth, { ...range('direction'), step: 1 }, (v) => set('direction', v)),
-    num('height', angles.elevation, { ...range('height'), step: 1 }, (v) => set('height', v)),
-    num('ambient', rig.ambient, range('ambient'), (v) => set('ambient', v)),
-    num('studio', rig.studio, range('studio'), (v) => set('studio', v)),
-    num('haze', light.haze ?? 1, range('haze'), (v) => set('haze', v)),
-    touched
-      ? button('reset to preset', () => patch({ light: {} }), 'lightReset')
-      : note('lightNote', `these are ${preset}'s own numbers — move one and it becomes yours`),
-  ]
 }

--- a/apps/editor/src/panels/backdropControls.ts
+++ b/apps/editor/src/panels/backdropControls.ts
@@ -1,0 +1,59 @@
+import { backdropSchema, type BackdropConfig } from 'paperlab'
+import { pickImageAsDataUrl } from '../chrome/pickImage'
+import { button, folder, schemaControls, text, toggle, type Control } from '../controls/controlModel'
+
+/** What the `image` field shows in place of a 200KB base64 string. */
+const UPLOADED = '(uploaded image)'
+
+/**
+ * What is behind the sheet.
+ *
+ * A toggle rather than a folder of always-on sliders, because the backdrop
+ * is OPTIONAL in the schema and unset means "leave the canvas alone" — the
+ * same shape `surface.deckle` and `content.wash` already have. An unset
+ * optional object drawn by the schema walk reads as a black backdrop that is
+ * switched on, which is a different thing from no backdrop at all.
+ *
+ * Shared by Paper and Field. Stage is deliberately not offered one: it has a
+ * room, with a ground and walls and a light at the end of it, and a flat
+ * picture pinned behind all that is two backgrounds arguing.
+ */
+export function backdropControls(
+  backdrop: BackdropConfig | undefined,
+  set: (next: BackdropConfig | undefined, opts?: { external?: boolean }) => void,
+): Control[] {
+  const controls: Control[] = [
+    toggle('backdrop', Boolean(backdrop), (on) =>
+      set(on ? backdropSchema.parse({}) : undefined, { external: true }),
+    ),
+  ]
+  if (!backdrop) return controls
+
+  return [
+    ...controls,
+    folder('Backdrop', [
+      text(
+        'image',
+        backdrop.image.startsWith('data:') ? UPLOADED : backdrop.image,
+        (v) => {
+          // Editing the mask itself would replace the picture with the words.
+          if (v !== UPLOADED) set({ ...backdrop, image: v })
+        },
+        { hint: 'a URL, or upload a file below' },
+      ),
+      button('upload backdrop', () => {
+        void pickImageAsDataUrl().then((dataUrl) => {
+          // external → the inspector remounts and the field shows the mask.
+          if (dataUrl) set({ ...backdrop, image: dataUrl }, { external: true })
+        })
+      }),
+      // `image` is the field above; the rest is colour, fit, fade and blur.
+      ...schemaControls(
+        backdropSchema,
+        backdrop as unknown as Record<string, unknown>,
+        (key, value) => set({ ...backdrop, [key]: value } as BackdropConfig),
+        ['image'],
+      ),
+    ]),
+  ]
+}

--- a/apps/editor/src/panels/lightControls.ts
+++ b/apps/editor/src/panels/lightControls.ts
@@ -1,0 +1,50 @@
+import {
+  lightAngles,
+  lightSchema,
+  lightingNames,
+  resolveLighting,
+  type LightOverrides,
+  type LightingName,
+} from 'paperlab'
+import { button, color, note, num, numberRange, select, type Control } from '../controls/controlModel'
+
+/**
+ * The light panel, built by hand for one reason: every field is an OVERRIDE.
+ *
+ * A generated slider reads its value out of the config, and an unset
+ * override has none — the whole point is that it means "whatever the preset
+ * says". So the sliders show the RESOLVED rig, which is the number the
+ * scene is actually using, and touching one writes that field and only that
+ * field. Reset drops the overrides and hands the look back to the preset.
+ *
+ * Direction and height are the same two angles Blender's light panel asks
+ * for rather than a position vector, because "where is the light" is a
+ * question about the room and not about the coordinate system.
+ */
+export function lightControls(
+  values: Record<string, unknown>,
+  patch: (patch: Record<string, unknown>) => void,
+): Control[] {
+  const preset = values.lighting as LightingName
+  const light = (values.light ?? {}) as LightOverrides
+  const rig = resolveLighting(preset, light)
+  const angles = lightAngles(rig.key.position)
+  const set = (key: keyof LightOverrides, value: unknown) => patch({ light: { ...light, [key]: value } })
+  const range = (key: keyof LightOverrides) => numberRange(lightSchema, key)
+  const touched = Object.values(light).some((v) => v !== undefined)
+
+  return [
+    select('preset', preset, [...lightingNames], (v) => patch({ lighting: v })),
+    num('exposure', rig.exposure, range('exposure'), (v) => set('exposure', v)),
+    num('key', rig.key.intensity, range('key'), (v) => set('key', v)),
+    color('color', rig.key.color, (v) => set('color', v)),
+    num('direction', angles.azimuth, { ...range('direction'), step: 1 }, (v) => set('direction', v)),
+    num('height', angles.elevation, { ...range('height'), step: 1 }, (v) => set('height', v)),
+    num('ambient', rig.ambient, range('ambient'), (v) => set('ambient', v)),
+    num('studio', rig.studio, range('studio'), (v) => set('studio', v)),
+    num('haze', light.haze ?? 1, range('haze'), (v) => set('haze', v)),
+    touched
+      ? button('reset to preset', () => patch({ light: {} }), 'lightReset')
+      : note('lightNote', `these are ${preset}'s own numbers — move one and it becomes yours`),
+  ]
+}

--- a/apps/editor/src/state/session.test.ts
+++ b/apps/editor/src/state/session.test.ts
@@ -38,6 +38,7 @@ const baseInput = (): SessionInput => ({
     speed: 0.5,
     entrance: 'rise',
     slots: ['photo-print', 'photo-print'],
+    scene: {},
     slotStates: {},
     zones: [],
   },

--- a/apps/editor/src/state/session.ts
+++ b/apps/editor/src/state/session.ts
@@ -4,6 +4,7 @@ import {
   listLayouts,
   listPresets,
   paperConfigSchema,
+  sceneSchema,
   paperStatesSchema,
   type PaperStatesInput,
 } from 'paperlab'
@@ -65,6 +66,7 @@ const fieldSessionSchema = z.object({
   speed: z.number(),
   entrance: z.enum(['rise', 'scatter', 'none']),
   slots: z.array(z.string()).min(1),
+  scene: sceneSchema,
   // JSON turns the numeric slot keys into strings; they come back as numbers.
   slotStates: z.record(z.string(), paperStatesSchema),
   zones: z.array(zoneSchema),

--- a/apps/editor/src/state/store.ts
+++ b/apps/editor/src/state/store.ts
@@ -18,6 +18,7 @@ import {
   type PaperConfig,
   type PaperConfigInput,
   type PaperStatesInput,
+  type SceneConfigInput,
   type SurfaceConfig,
 } from 'paperlab'
 import {
@@ -58,6 +59,8 @@ export interface FieldState {
   entrance: 'rise' | 'scatter' | 'none'
   /** Preset name per slot — each field slot references a preset (components). */
   slots: string[]
+  /** How the gallery is lit — the same `{ lighting, light }` a sheet carries. */
+  scene: SceneConfigInput
   /** Per-slot state overrides (slot layer, merged over the preset's states). */
   slotStates: Record<number, PaperStatesInput>
   /** Drop zones — serialized into the field config and the export. */
@@ -278,6 +281,10 @@ const DEFAULT_FIELD: FieldState = {
   // content, and a museum label printed on gloss photo stock is the wrong
   // material. Matte printer stock is what a card is cut from.
   slots: Array.from({ length: 14 }, () => 'blank-sheet'),
+  // The schema's own rig. Field mode used to inherit whatever the first
+  // slot's preset happened to say, which meant the lighting of a gallery
+  // changed when you swapped one card in it.
+  scene: {},
   slotStates: {},
   zones: [],
 }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1252,6 +1252,44 @@ button.export:hover {
   font-size: 10px;
 }
 
+/* Swatch and hex together: the swatch is how you find a colour you have not
+   decided on, the field is how you paste one you have. */
+.control-color {
+  grid-column: 2 / -1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.control-color input[type="color"] {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 22px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--hair-2);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+/* The native swatch paints a chrome frame inside the element; strip it so the
+   control reads as one flat chip in a panel that has no other frames in it. */
+.control-color input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.control-color input[type="color"]::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.control-color .control-text {
+  grid-column: auto;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+}
+
 .control-toggle {
   grid-column: 2 / -1;
   justify-self: start;

--- a/packages/paperlab/src/Paper.tsx
+++ b/packages/paperlab/src/Paper.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react'
 import { PaperMesh, useResolvedConfig, type PaperHandle, type PaperMeshProps } from './PaperMesh'
 import { PaperFallback, PaperMirror, supportsWebGL } from './a11y'
 import { PaperLighting } from './scene/PaperLighting'
+import { PaperBackdrop } from './scene/backdrop'
 
 export interface PaperProps extends PaperMeshProps {
   /** Extra children rendered inside the canvas (lights are provided). */
@@ -33,8 +34,13 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
     <div className={className} style={{ width: '100%', height: '100%', ...style }}>
       {webgl ? (
         <Canvas shadows camera={{ position: [0, 0.35, 2.4], fov: 40 }} dpr={[1, 2]}>
+          <PaperBackdrop backdrop={config.scene.backdrop} />
           <PaperLighting
             preset={config.scene.lighting}
+            // The overrides, which this component was resolving without: a
+            // preset whose scene said "studio, but dimmer" rendered as plain
+            // studio here while the editor showed the dimmer one.
+            light={config.scene.light}
             floor={-1.05}
             scale={8}
             reducedMotion={meshProps.reducedMotion}

--- a/packages/paperlab/src/PaperField.tsx
+++ b/packages/paperlab/src/PaperField.tsx
@@ -2,7 +2,8 @@ import * as THREE from 'three'
 import { gsap } from 'gsap'
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { forwardRef, useEffect, useMemo, useRef } from 'react'
-import type { PaperConfigInput } from './config/schema'
+import { sceneSchema, type PaperConfigInput, type SceneConfigInput } from './config/schema'
+import { PaperLighting } from './scene/PaperLighting'
 import { usePrefersReducedMotion } from './a11y'
 import { DropZoneContext, DropZoneRegistry, type DropZoneConfig, type PlacedPaper } from './field/dropZones'
 import {
@@ -80,6 +81,16 @@ export interface PaperFieldMeshProps {
 }
 
 export interface PaperFieldProps extends PaperFieldMeshProps {
+  /**
+   * Lighting — the same `{ lighting, light }` a single sheet carries.
+   *
+   * This component used to light itself with a bare ambient and a bare
+   * directional, while the editor previewed field mode through
+   * `<PaperLighting>` like everything else. So the gallery you composed and
+   * the gallery the exported code produced were lit by two different rigs,
+   * and the export was the one nobody had looked at.
+   */
+  scene?: SceneConfigInput
   children?: React.ReactNode
   className?: string
   style?: React.CSSProperties
@@ -288,9 +299,10 @@ function FitCamera(meshProps: PaperFieldMeshProps) {
 
 /** `<PaperField />` owns its own Canvas; PaperFieldMesh drops into existing scenes. */
 export const PaperField = forwardRef<THREE.Group, PaperFieldProps>(function PaperField(
-  { children, className, style, ...meshProps },
+  { children, className, style, scene, ...meshProps },
   ref,
 ) {
+  const rig = sceneSchema.parse(scene ?? {})
   const registry = useMemo(() => new DropZoneRegistry(), [])
   const a11yRef = useRef<FieldA11yController | null>(null)
 
@@ -313,14 +325,9 @@ export const PaperField = forwardRef<THREE.Group, PaperFieldProps>(function Pape
       <DropZoneContext.Provider value={registry}>
         <Canvas shadows camera={{ position: [0, 0.6, 5.2], fov: 45 }} dpr={[1, 2]}>
           <FitCamera {...meshProps} />
-          <ambientLight intensity={0.7} />
-          <directionalLight
-            position={[3, 5, 4]}
-            intensity={1.4}
-            castShadow
-            shadow-mapSize={[1024, 1024]}
-            shadow-normalBias={0.05}
-          />
+          {/* The floor and footprint a gallery of sheets needs — a lone sheet
+              sits closer to the camera and on a tighter shadow. */}
+          <PaperLighting preset={rig.lighting} light={rig.light} floor={-2.4} scale={14} />
           <PaperFieldMesh ref={ref} a11yControllerRef={a11yRef} {...meshProps} />
           {children}
         </Canvas>

--- a/packages/paperlab/src/PaperField.tsx
+++ b/packages/paperlab/src/PaperField.tsx
@@ -4,6 +4,7 @@ import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { forwardRef, useEffect, useMemo, useRef } from 'react'
 import { sceneSchema, type PaperConfigInput, type SceneConfigInput } from './config/schema'
 import { PaperLighting } from './scene/PaperLighting'
+import { PaperBackdrop } from './scene/backdrop'
 import { usePrefersReducedMotion } from './a11y'
 import { DropZoneContext, DropZoneRegistry, type DropZoneConfig, type PlacedPaper } from './field/dropZones'
 import {
@@ -325,6 +326,7 @@ export const PaperField = forwardRef<THREE.Group, PaperFieldProps>(function Pape
       <DropZoneContext.Provider value={registry}>
         <Canvas shadows camera={{ position: [0, 0.6, 5.2], fov: 45 }} dpr={[1, 2]}>
           <FitCamera {...meshProps} />
+          <PaperBackdrop backdrop={rig.backdrop} />
           {/* The floor and footprint a gallery of sheets needs — a lone sheet
               sits closer to the camera and on a tighter shadow. */}
           <PaperLighting preset={rig.lighting} light={rig.light} floor={-2.4} scale={14} />

--- a/packages/paperlab/src/config/agent-payload.ts
+++ b/packages/paperlab/src/config/agent-payload.ts
@@ -1,6 +1,6 @@
 import type { PaperConfig } from './schema'
 import { getStock } from '../core/stock'
-import { diffConfig } from './diff'
+import { UPLOAD_NOTE, diffConfig, withoutUploads } from './diff'
 
 /**
  * The primary export consumer is a coding agent; the human is the courier.
@@ -88,7 +88,12 @@ function componentName(config: PaperConfig): string {
 /** The self-contained integration brief — one paste into a coding agent. */
 export function buildAgentPayload(config: PaperConfig): string {
   const name = componentName(config)
-  const preset = JSON.stringify(diffConfig(config), null, 2)
+  // Uploaded pictures become paths: this payload is pasted into a coding
+  // agent's context window, and a hundred kilobytes of base64 in there is
+  // both useless and expensive.
+  const { value: stripped, replaced } = withoutUploads(diffConfig(config))
+  const preset = JSON.stringify(stripped, null, 2)
+  const uploadNote = replaced > 0 ? `${UPLOAD_NOTE}\n` : ''
 
   return `Integrate a Paperlab paper component into this project. (paperlab agent-payload v${AGENT_PAYLOAD_VERSION})
 
@@ -102,7 +107,7 @@ export function buildAgentPayload(config: PaperConfig): string {
 \`\`\`tsx
 import { Paper, type PaperConfigInput } from 'paperlab'
 
-const preset = ${preset.replace(/\n/g, '\n')} satisfies PaperConfigInput
+${uploadNote}const preset = ${preset.replace(/\n/g, '\n')} satisfies PaperConfigInput
 
 export function ${name}() {
   return <Paper preset={preset} />

--- a/packages/paperlab/src/config/diff.ts
+++ b/packages/paperlab/src/config/diff.ts
@@ -3,6 +3,7 @@ import {
   clothConfigSchema,
   contentSchema,
   paperConfigSchema,
+  sceneSchema,
   sheetSchema,
   type PaperConfig,
   type PaperConfigInput,
@@ -77,7 +78,14 @@ export function diffConfig(config: PaperConfig): PaperConfigInput {
     out.physics = config.physics
   }
 
-  if (config.scene.lighting !== 'studio') out.scene = { lighting: config.scene.lighting }
+  // The WHOLE scene, diffed like everything else. This used to read
+  // `if (lighting !== 'studio') out.scene = { lighting }` — which was true
+  // while `lighting` was the only thing in a scene, and quietly threw away
+  // every field added beside it. A hand-tuned light rig and a backdrop both
+  // vanished on the way into a `.paper` file, a share link and a snippet:
+  // the editor showed them and nothing that left the editor carried them.
+  const scene = diffAgainst(config.scene as never, sceneSchema.parse({}) as never)
+  if (Object.keys(scene).length > 0) out.scene = scene
   if (config.onTwos) out.onTwos = true
   // States are already diffs on the base — emit them whole.
   if (config.states) out.states = config.states
@@ -94,13 +102,56 @@ function jsxValue(value: unknown): string {
 }
 
 /**
+ * The same config with uploaded pictures swapped for paths.
+ *
+ * An uploaded image lives in a config as a data URL — a hundred kilobytes
+ * and up of base64 — and there are now two places one can be: the sheet's
+ * own content, and the backdrop behind it. Pasting that into somebody's
+ * source file is not an export, and the reader cannot edit it, diff it, or
+ * even scroll past it.
+ *
+ * So a code export gets a path in the same position instead, and says that
+ * is what it did. A referenced URL is already something the receiver can
+ * fetch and travels untouched. Emitting nothing was the other option and it
+ * is worse: a sheet that silently loses its picture looks like a bug in the
+ * library rather than a limit of the clipboard.
+ *
+ * The `.paper` file and the share link are deliberately NOT run through
+ * this — a file has room for the bytes, and losing them there would lose
+ * the artwork rather than reformat it.
+ */
+export function withoutUploads<T>(value: T): { value: T; replaced: number } {
+  let replaced = 0
+  const walk = (node: unknown): unknown => {
+    if (typeof node === 'string') {
+      if (!node.startsWith('data:')) return node
+      replaced++
+      const extension = node.startsWith('data:image/png') ? 'png' : 'jpg'
+      return `/paperlab-image-${replaced}.${extension}`
+    }
+    if (Array.isArray(node)) return node.map(walk)
+    if (node && typeof node === 'object') {
+      return Object.fromEntries(Object.entries(node).map(([k, v]) => [k, walk(v)]))
+    }
+    return node
+  }
+  return { value: walk(value) as T, replaced }
+}
+
+/** The one-line warning a code export carries when it had to substitute. */
+export const UPLOAD_NOTE =
+  '// Uploaded pictures cannot travel in a snippet — the paths below are\n// stand-ins, in order. Point them at your own files.'
+
+/**
  * A plain `<Paper />` snippet with only the non-default props — the
  * secondary export for people who read code.
  */
 export function buildJsxSnippet(config: PaperConfig): string {
-  const diff = diffConfig(config) as Record<string, unknown>
-  delete diff.meta
+  const diffed = diffConfig(config) as Record<string, unknown>
+  delete diffed.meta
+  const { value: diff, replaced } = withoutUploads(diffed)
   const props = Object.entries(diff).map(([key, value]) => `  ${key}=${jsxValue(value)}`)
   if (props.length === 0) return '<Paper />'
-  return `<Paper\n${props.join('\n')}\n/>`
+  const snippet = `<Paper\n${props.join('\n')}\n/>`
+  return replaced > 0 ? `${UPLOAD_NOTE}\n${snippet}` : snippet
 }

--- a/packages/paperlab/src/config/export.test.ts
+++ b/packages/paperlab/src/config/export.test.ts
@@ -130,3 +130,75 @@ describe('onTwos quantizer', () => {
     expect(quantizeProgress(0.53, 2)).toBeCloseTo(13 / 24)
   })
 })
+
+describe('the scene survives the trip out', () => {
+  const parse = (scene: unknown) => paperConfigSchema.parse({ scene })
+  const upload = 'data:image/jpeg;base64,AAAA'
+
+  it('says nothing about a scene nobody touched', () => {
+    expect(diffConfig(parse({}))).not.toHaveProperty('scene')
+    expect(diffConfig(parse({ lighting: 'studio' }))).not.toHaveProperty('scene')
+  })
+
+  it('carries a named preset', () => {
+    expect(diffConfig(parse({ lighting: 'nave' })).scene).toEqual({ lighting: 'nave' })
+  })
+
+  it('carries hand-moved light overrides', () => {
+    // This is what the old `if (lighting !== "studio") out.scene = { lighting }`
+    // threw away: the editor showed a tuned rig and nothing that left the
+    // editor — file, link or snippet — carried a single number of it.
+    expect(diffConfig(parse({ light: { exposure: 1.8, key: 6 } })).scene).toEqual({
+      light: { exposure: 1.8, key: 6 },
+    })
+  })
+
+  it('carries only the overrides that were moved', () => {
+    // An unset field means "whatever the preset says"; freezing the resolved
+    // rig would stop it tracking the preset it names.
+    const scene = diffConfig(parse({ lighting: 'nave', light: { haze: 0.4 } })).scene
+    expect(scene).toEqual({ lighting: 'nave', light: { haze: 0.4 } })
+  })
+
+  it('carries a backdrop', () => {
+    const scene = diffConfig(parse({ backdrop: { image: '/wall.jpg' } })).scene
+    expect(scene).toMatchObject({ backdrop: { image: '/wall.jpg', fit: 'cover' } })
+  })
+
+  it('round-trips: what the diff emits parses back to what went in', () => {
+    const original = parse({ lighting: 'nave', light: { exposure: 1.8 }, backdrop: { image: '/w.jpg' } })
+    expect(paperConfigSchema.parse(diffConfig(original)).scene).toEqual(original.scene)
+  })
+
+  it('swaps an uploaded backdrop for a path in a code export, and says so', () => {
+    const jsx = buildJsxSnippet(parse({ backdrop: { image: upload } }))
+    expect(jsx).not.toContain('base64')
+    expect(jsx).toContain('/paperlab-image-1.jpg')
+    expect(jsx).toContain('stand-ins')
+  })
+
+  it('swaps an uploaded sheet picture too', () => {
+    // Same problem, and it was there before backdrops were: an uploaded
+    // content image put its whole base64 into the snippet.
+    const config = paperConfigSchema.parse({ content: { type: 'image', src: upload } })
+    expect(buildJsxSnippet(config)).not.toContain('base64')
+    expect(buildAgentPayload(config)).not.toContain('base64')
+  })
+
+  it('leaves a referenced URL exactly as it is', () => {
+    // A path the receiver can fetch is the case that already works.
+    const jsx = buildJsxSnippet(parse({ backdrop: { image: 'https://example.com/w.jpg' } }))
+    expect(jsx).toContain('https://example.com/w.jpg')
+    expect(jsx).not.toContain('stand-ins')
+  })
+
+  it('numbers the stand-ins so two pictures do not become one', () => {
+    const config = paperConfigSchema.parse({
+      content: { type: 'image', src: upload },
+      scene: { backdrop: { image: upload } },
+    })
+    const jsx = buildJsxSnippet(config)
+    expect(jsx).toContain('/paperlab-image-1.jpg')
+    expect(jsx).toContain('/paperlab-image-2.jpg')
+  })
+})

--- a/packages/paperlab/src/config/field-export.test.ts
+++ b/packages/paperlab/src/config/field-export.test.ts
@@ -9,6 +9,7 @@ import {
 } from './field-export'
 import { AGENT_PAYLOAD_VERSION } from './agent-payload'
 import { getPreset } from './presets'
+import { getLayout } from '../field/layouts'
 import { groupFieldPapers } from '../field/slots'
 import { zoneAccepts } from '../field/dropZones'
 
@@ -177,5 +178,50 @@ describe('groupFieldPapers', () => {
     const groups = groupFieldPapers([{}, { preset: 'receipt-unroll' }], 'photo-print')
     expect(groups).toHaveLength(2)
     expect(groups[0]!.config.stock).toBe('photo-gloss')
+  })
+})
+
+describe('how the gallery is lit', () => {
+  const field = (scene?: FieldExportInput['scene']): FieldExportInput => ({
+    layout: 'ring',
+    papers: [{ presetName: 'photo-print', preset: photo }],
+    ...(scene ? { scene } : {}),
+  })
+
+  it('says nothing when the rig is the default one', () => {
+    // A `scene` prop repeating what the schema already says is noise in
+    // somebody's file.
+    expect(diffFieldProps(field())).not.toHaveProperty('scene')
+    expect(diffFieldProps(field({}))).not.toHaveProperty('scene')
+    expect(diffFieldProps(field({ lighting: 'studio' }))).not.toHaveProperty('scene')
+  })
+
+  it('carries a named preset that is not the default', () => {
+    expect(diffFieldProps(field({ lighting: 'nave' })).scene).toEqual({ lighting: 'nave' })
+  })
+
+  it('carries hand-moved overrides, and only those', () => {
+    // Unset fields mean "whatever the preset says", so an export that froze
+    // the whole resolved rig would stop tracking the preset it names.
+    expect(diffFieldProps(field({ light: { exposure: 1.8 } })).scene).toEqual({
+      light: { exposure: 1.8 },
+    })
+  })
+
+  it('writes the scene into the component the editor previews', () => {
+    // The editor lit field mode through PaperLighting while <PaperField> lit
+    // itself with a bare ambient and directional, so the gallery you composed
+    // and the code you exported were two different pictures.
+    const source = buildFieldComponentSource(field({ lighting: 'nave' }))
+    expect(source).toContain('scene=')
+    expect(source).toContain('nave')
+  })
+
+  it('compares structurally, so an array equal to its default stays out', () => {
+    // `nonDefault` used to compare by reference, and no object or array
+    // copied from a default is ever reference-equal to it.
+    const defaults = getLayout('ring').defaults as Record<string, unknown>
+    const props = diffFieldProps({ ...field(), layoutOptions: { ...defaults } })
+    expect(props).not.toHaveProperty('layoutOptions')
   })
 })

--- a/packages/paperlab/src/config/field-export.ts
+++ b/packages/paperlab/src/config/field-export.ts
@@ -1,4 +1,10 @@
-import type { ContentConfig, PaperConfig, PaperStatesInput } from './schema'
+import {
+  sceneSchema,
+  type ContentConfig,
+  type PaperConfig,
+  type PaperStatesInput,
+  type SceneConfigInput,
+} from './schema'
 import { diffConfig } from './diff'
 import { AGENT_PAYLOAD_VERSION } from './agent-payload'
 import { getLayout } from '../field/layouts'
@@ -32,6 +38,8 @@ export interface FieldExportInput {
   motion?: { driver?: 'autoplay' | 'drag' | 'none'; speed?: number }
   entrance?: { type?: 'rise' | 'scatter' | 'none'; stagger?: number; duration?: number }
   papers: FieldExportPaper[]
+  /** How the gallery is lit. Omitted means the schema's own default rig. */
+  scene?: SceneConfigInput
   /** Drop zones — exported as `<DropZone>` children with an onPlace stub. */
   zones?: FieldExportZone[]
 }
@@ -66,13 +74,24 @@ export function distinctFieldPresets(input: FieldExportInput): DistinctPreset[] 
   return [...byKey.values()]
 }
 
+/**
+ * The entries that differ from the defaults.
+ *
+ * Compared STRUCTURALLY rather than by reference. Most of what passes
+ * through here is numbers and strings, where the two agree — but a layout
+ * option holding an array, or a scene holding a nested rig, is never
+ * reference-equal to the default it was copied from, so those exported a
+ * prop that said exactly what the default already said.
+ */
 function nonDefault<T extends Record<string, unknown>>(
   value: T | undefined,
   defaults: Record<string, unknown>,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(value ?? {})) {
-    if (v !== undefined && v !== defaults[k]) out[k] = v
+    if (v === undefined) continue
+    const same = v === defaults[k] || JSON.stringify(v) === JSON.stringify(defaults[k])
+    if (!same) out[k] = v
   }
   return out
 }
@@ -87,6 +106,14 @@ export function diffFieldProps(input: FieldExportInput): Record<string, unknown>
   if (Object.keys(motion).length > 0) out.motion = motion
   const entrance = nonDefault(input.entrance, ENTRANCE_DEFAULTS)
   if (Object.keys(entrance).length > 0) out.entrance = entrance
+  // Resolved through the schema before comparing, so an input naming only
+  // `lighting` is judged against a whole default rig rather than a
+  // half-filled one.
+  const scene = nonDefault(
+    sceneSchema.parse(input.scene ?? {}) as unknown as Record<string, unknown>,
+    sceneSchema.parse({}) as unknown as Record<string, unknown>,
+  )
+  if (Object.keys(scene).length > 0) out.scene = scene
   return out
 }
 

--- a/packages/paperlab/src/config/schema.ts
+++ b/packages/paperlab/src/config/schema.ts
@@ -92,9 +92,9 @@ export type StockName = z.infer<typeof stockSchema>
  */
 export const washSchema = z.object({
   /** The first pigment. */
-  color: z.string().default('#4a5b8c'),
+  color: z.string().default('#4a5b8c').describe('color'),
   /** The second. Blooms alternate, and overlaps multiply into a third. */
-  secondary: z.string().default('#b06a6a'),
+  secondary: z.string().default('#b06a6a').describe('color'),
   /** How many pools of colour. */
   blooms: z.number().int().min(1).max(24).default(7),
   /** How far a pool runs before it dries — its size against the sheet. */
@@ -144,7 +144,7 @@ const textContentBase = z.object({
   /** px at texture resolution (long edge = 1024 logical px before DPR). */
   size: z.number().min(8).max(256).default(44),
   weight: z.number().min(100).max(900).default(400),
-  color: z.string().default('#2b2620'),
+  color: z.string().default('#2b2620').describe('color'),
   align: z.enum(['left', 'center', 'right']).default('left'),
   /** Fraction of the short edge. */
   padding: z.number().min(0).max(0.4).default(0.09),
@@ -208,7 +208,7 @@ const cardContentBase = z.object({
    * was cropped rather than as a card that was set.
    */
   size: z.number().min(8).max(256).default(58),
-  color: z.string().default('#2b2620'),
+  color: z.string().default('#2b2620').describe('color'),
   align: z.enum(['left', 'center']).default('left'),
   padding: z.number().min(0).max(0.4).default(0.1),
 })
@@ -453,8 +453,62 @@ export const lightingNames = [
 export const filmNames = ['agx', 'neutral', 'filmic'] as const
 
 /** Scene-level presentation, serialized with the paper. */
+/**
+ * Overrides on top of a named preset — the Blender-panel half of lighting.
+ *
+ * Every field is optional ON PURPOSE. An unset field means "whatever the
+ * preset says", so a shared link carries the two sliders you actually moved
+ * rather than a frozen copy of a rig you never touched, and re-basing onto
+ * another preset keeps your intent instead of your numbers.
+ */
+export const lightSchema = z.object({
+  /** Tone-mapping exposure — the stop the whole picture is printed at. */
+  exposure: z.number().min(0.1).max(4).optional(),
+  /**
+   * The tone curve — the film, where `exposure` is the stop.
+   *
+   * `filmic` is ACES, which is what every preset used to be pinned to and is
+   * kept so a scene tuned against it can say so. On near-white paper it is
+   * the wrong film: it desaturates and drags bright neutrals toward
+   * yellow-green, which is the sepia cast a lit sheet used to pick up.
+   */
+  film: z.enum(filmNames).optional(),
+  /** Key light strength. */
+  key: z.number().min(0).max(12).optional(),
+  /** Key light colour. */
+  color: z.string().optional().describe('color'),
+  /**
+   * Where the key stands, degrees around the vertical. 0° is straight in
+   * front of the paper (+Z, beside the camera), 90° is off to the right,
+   * and ±180° is directly behind it — which is where `nave` puts it, and
+   * why that preset is carried by light coming THROUGH the paper.
+   */
+  direction: z.number().min(-180).max(180).optional(),
+  /** How high the key stands, degrees above the horizon. */
+  height: z.number().min(-30).max(89).optional(),
+  /** Flat fill from every direction at once. Cheap, and it kills form — reach for `studio` first. */
+  ambient: z.number().min(0).max(2).optional(),
+  /** The room's own light: an environment map built from `sky`. Directional fill, and the only thing paper's sheen has to reflect. */
+  studio: z.number().min(0).max(3).optional(),
+  /** Distance haze, as a multiple of the preset's. 0 clears the air entirely; 2 halves the distance you can see. */
+  haze: z.number().min(0).max(3).optional(),
+})
+
+export type LightOverrides = z.infer<typeof lightSchema>
+export type LightOverridesInput = z.input<typeof lightSchema>
+
 export const sceneSchema = z.object({
   lighting: z.enum(lightingNames).default('studio'),
+  /**
+   * Overrides on the named preset — the same authorable half stage mode has
+   * always had, and which a lone sheet had no way to reach.
+   *
+   * A preset was the starting point everywhere EXCEPT here: a stage could be
+   * "nave, but the sun is lower", and a `<Paper>` could only be one of seven
+   * rigs exactly as shipped. `<PaperLighting>` has taken these overrides all
+   * along; nothing was passing them.
+   */
+  light: lightSchema.default({}),
 })
 
 export type SceneConfig = z.infer<typeof sceneSchema>

--- a/packages/paperlab/src/config/schema.ts
+++ b/packages/paperlab/src/config/schema.ts
@@ -497,8 +497,45 @@ export const lightSchema = z.object({
 export type LightOverrides = z.infer<typeof lightSchema>
 export type LightOverridesInput = z.input<typeof lightSchema>
 
+/**
+ * What is behind the sheet.
+ *
+ * Optional, and that is deliberate: an unset backdrop means the canvas is
+ * left exactly as it was found. `<Paper>` has always rendered onto whatever
+ * is behind it, and a default that painted the frame would change the look
+ * of every sheet already on a page.
+ *
+ * It is part of the CONFIG rather than a preview trick in the editor,
+ * because the whole export story is that the code you copy makes the picture
+ * you were looking at. A backdrop that existed only in the editor would make
+ * the most-photographed part of a composition the one thing that does not
+ * travel.
+ */
+export const backdropSchema = z.object({
+  /** Behind everything, and behind the picture where it does not reach. */
+  color: z.string().default('#171717').describe('color'),
+  /** A URL, or an uploaded picture. Empty is the colour on its own. */
+  image: z.string().default(''),
+  fit: z.enum(['cover', 'contain']).default('cover'),
+  /**
+   * Toward the colour, so the paper stays the subject.
+   *
+   * A backdrop at full strength competes with the sheet in front of it —
+   * which is what a real photographer solves by putting the background out
+   * of the light, and what this solves by mixing it back toward the ground
+   * it sits on.
+   */
+  fade: z.number().min(0).max(1).default(0.25),
+  /** Out of focus, for the same reason. */
+  blur: z.number().min(0).max(1).default(0.2),
+})
+
+export type BackdropConfig = z.infer<typeof backdropSchema>
+
 export const sceneSchema = z.object({
   lighting: z.enum(lightingNames).default('studio'),
+  /** What is behind the sheet. Unset leaves the canvas alone. */
+  backdrop: backdropSchema.optional(),
   /**
    * Overrides on the named preset — the same authorable half stage mode has
    * always had, and which a lone sheet had no way to reach.

--- a/packages/paperlab/src/index.ts
+++ b/packages/paperlab/src/index.ts
@@ -38,6 +38,7 @@ export {
 export {
   paperConfigSchema,
   sceneSchema,
+  backdropSchema,
   behaviorConfigSchema,
   clothConfigSchema,
   paperStatesSchema,
@@ -69,6 +70,7 @@ export {
   type PhysicsConfigInput,
   type ClothConfig,
   type SceneConfig,
+  type BackdropConfig,
   type SceneConfigInput,
   type LightingName,
   type FilmName,
@@ -130,6 +132,8 @@ export {
   type LightOverridesInput,
 } from './scene/lighting'
 export { PaperLighting, type PaperLightingProps } from './scene/PaperLighting'
+// Rendered by whoever owns the canvas — see the note on the component.
+export { PaperBackdrop } from './scene/backdrop'
 // Publish a resolved rig to the paper under it, so a hand-lit scene's
 // transmission agrees with its lamps. `<PaperStage>` does this for you.
 export { LightRig } from './scene/rig'

--- a/packages/paperlab/src/index.ts
+++ b/packages/paperlab/src/index.ts
@@ -37,6 +37,7 @@ export {
 
 export {
   paperConfigSchema,
+  sceneSchema,
   behaviorConfigSchema,
   clothConfigSchema,
   paperStatesSchema,

--- a/packages/paperlab/src/scene/backdrop.tsx
+++ b/packages/paperlab/src/scene/backdrop.tsx
@@ -1,0 +1,109 @@
+import * as THREE from 'three'
+import { useEffect, useState } from 'react'
+import { useThree } from '@react-three/fiber'
+import type { BackdropConfig } from '../config/schema'
+
+/**
+ * What is behind the sheet.
+ *
+ * Painted onto a canvas at the viewport's own size and handed to
+ * `scene.background`, rather than assigned as a texture directly. Three
+ * stretches a background texture to the frame whatever shape it is, so a
+ * landscape photograph behind a 9:16 export would come out squashed — and
+ * the export sizes are exactly where a backdrop matters most. Painting it
+ * means `cover` is really cover, and `fade` and `blur` come along for free
+ * in the same pass.
+ *
+ * It sets the SCENE's background, so it belongs to whoever owns the canvas.
+ * `<Paper>` and `<PaperField>` render it; `<PaperMesh>` deliberately does
+ * not — it drops into someone else's scene, and a sheet that repainted the
+ * background of the app it was embedded in would be a component doing
+ * something nobody asked it to.
+ */
+export function PaperBackdrop({ backdrop }: { backdrop?: BackdropConfig }) {
+  const scene = useThree((s) => s.scene)
+  const size = useThree((s) => s.size)
+  const [image, setImage] = useState<HTMLImageElement | null>(null)
+
+  const src = backdrop?.image ?? ''
+
+  useEffect(() => {
+    if (!src) {
+      setImage(null)
+      return
+    }
+    let live = true
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    // A picture that will not load leaves the colour, which is the honest
+    // rendering of "no backdrop image" — not a black frame and not a throw.
+    img.onload = () => live && setImage(img)
+    img.onerror = () => live && setImage(null)
+    img.src = src
+    return () => {
+      live = false
+    }
+  }, [src])
+
+  const key = JSON.stringify({ backdrop: backdrop ?? null, w: size.width, h: size.height, loaded: !!image })
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: key serializes everything the paint reads.
+  useEffect(() => {
+    if (!backdrop) return
+    const previous = scene.background
+    const texture = paintBackdrop(backdrop, size.width, size.height, image)
+    scene.background = texture
+    return () => {
+      scene.background = previous
+      texture.dispose()
+    }
+  }, [key])
+
+  return null
+}
+
+/** Exported for the test — the painting is the part that can be wrong. */
+export function paintBackdrop(
+  backdrop: BackdropConfig,
+  width: number,
+  height: number,
+  image: HTMLImageElement | null,
+): THREE.CanvasTexture {
+  // Half resolution. It is out of focus behind the subject and it is drawn
+  // once per resize, so the pixels buy nothing and the memory is real.
+  const w = Math.max(2, Math.round(width / 2))
+  const h = Math.max(2, Math.round(height / 2))
+  const canvas = document.createElement('canvas')
+  canvas.width = w
+  canvas.height = h
+  const ctx = canvas.getContext('2d')!
+
+  ctx.fillStyle = backdrop.color
+  ctx.fillRect(0, 0, w, h)
+
+  if (image && image.width > 0 && image.height > 0) {
+    const scale =
+      backdrop.fit === 'cover'
+        ? Math.max(w / image.width, h / image.height)
+        : Math.min(w / image.width, h / image.height)
+    const dw = image.width * scale
+    const dh = image.height * scale
+    ctx.save()
+    // Scaled by the SHORT edge: a blur measured in pixels is a different
+    // amount of blur on a phone frame than on a hero, and the backdrop
+    // should sit the same distance behind the paper in both.
+    if (backdrop.blur > 0) ctx.filter = `blur(${backdrop.blur * Math.min(w, h) * 0.06}px)`
+    ctx.drawImage(image, (w - dw) / 2, (h - dh) / 2, dw, dh)
+    ctx.restore()
+    if (backdrop.fade > 0) {
+      ctx.globalAlpha = backdrop.fade
+      ctx.fillStyle = backdrop.color
+      ctx.fillRect(0, 0, w, h)
+      ctx.globalAlpha = 1
+    }
+  }
+
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.colorSpace = THREE.SRGBColorSpace
+  return texture
+}

--- a/packages/paperlab/src/scene/lighting.ts
+++ b/packages/paperlab/src/scene/lighting.ts
@@ -1,5 +1,4 @@
-import { z } from 'zod'
-import { filmNames, type FilmName, type LightingName } from '../config/schema'
+import type { FilmName, LightOverrides, LightingName } from '../config/schema'
 
 /**
  * Lighting presets: each is a key light + ambient level + contact shadow +
@@ -224,49 +223,12 @@ export function getLightingPreset(name: LightingName): LightingPreset {
 
 // ── The authorable half ─────────────────────────────────────────────────────
 
-/**
- * Overrides on top of a named preset — the Blender-panel half of lighting.
- *
- * Every field is optional ON PURPOSE. An unset field means "whatever the
- * preset says", so a shared link carries the two sliders you actually moved
- * rather than a frozen copy of a rig you never touched, and re-basing onto
- * another preset keeps your intent instead of your numbers.
- */
-export const lightSchema = z.object({
-  /** Tone-mapping exposure — the stop the whole picture is printed at. */
-  exposure: z.number().min(0.1).max(4).optional(),
-  /**
-   * The tone curve — the film, where `exposure` is the stop.
-   *
-   * `filmic` is ACES, which is what every preset used to be pinned to and is
-   * kept so a scene tuned against it can say so. On near-white paper it is
-   * the wrong film: it desaturates and drags bright neutrals toward
-   * yellow-green, which is the sepia cast a lit sheet used to pick up.
-   */
-  film: z.enum(filmNames).optional(),
-  /** Key light strength. */
-  key: z.number().min(0).max(12).optional(),
-  /** Key light colour. */
-  color: z.string().optional(),
-  /**
-   * Where the key stands, degrees around the vertical. 0° is straight in
-   * front of the paper (+Z, beside the camera), 90° is off to the right,
-   * and ±180° is directly behind it — which is where `nave` puts it, and
-   * why that preset is carried by light coming THROUGH the paper.
-   */
-  direction: z.number().min(-180).max(180).optional(),
-  /** How high the key stands, degrees above the horizon. */
-  height: z.number().min(-30).max(89).optional(),
-  /** Flat fill from every direction at once. Cheap, and it kills form — reach for `studio` first. */
-  ambient: z.number().min(0).max(2).optional(),
-  /** The room's own light: an environment map built from `sky`. Directional fill, and the only thing paper's sheen has to reflect. */
-  studio: z.number().min(0).max(3).optional(),
-  /** Distance haze, as a multiple of the preset's. 0 clears the air entirely; 2 halves the distance you can see. */
-  haze: z.number().min(0).max(3).optional(),
-})
-
-export type LightOverrides = z.infer<typeof lightSchema>
-export type LightOverridesInput = z.input<typeof lightSchema>
+// `lightSchema` and its types live in `config/schema.ts` — they are part of
+// the serialized config, and `sceneSchema` needs them, which a schema that
+// imports FROM here cannot have. Re-exported because this is where the rig
+// they describe is resolved, and a caller reaching for the overrides looks
+// for them beside `resolveLighting`.
+export { lightSchema, type LightOverrides, type LightOverridesInput } from '../config/schema'
 
 /** Where a light stands, in the terms a person would say it in. */
 export interface LightAngles {

--- a/packages/paperlab/src/stage/gait.ts
+++ b/packages/paperlab/src/stage/gait.ts
@@ -24,7 +24,7 @@ export const figureSchema = z.object({
   /** Arm swing, 0..1. Drop it toward 0 for hands-in-pockets stillness. */
   swing: z.number().min(0).max(1).default(1),
   /** Silhouette color. Near-black by default: it should read as an absence, not an object. */
-  color: z.string().default('#0a0a0c'),
+  color: z.string().default('#0a0a0c').describe('color'),
   /**
    * How the figure takes light.
    *

--- a/packages/paperlab/src/stage/schema.ts
+++ b/packages/paperlab/src/stage/schema.ts
@@ -15,7 +15,7 @@ import { figureSchema } from './gait'
 export const stageSourceSchema = z.object({
   /** The bright void the walk resolves toward. Without it the vanishing point is a hole. */
   enabled: z.boolean().default(true),
-  color: z.string().default('#fff4e2'),
+  color: z.string().default('#fff4e2').describe('color'),
   /** How far past the end of the walk it stands, world units. */
   beyond: z.number().min(0).max(80).default(10),
   /**
@@ -48,7 +48,7 @@ export const stageGroundSchema = z.object({
    * kept its contrast against the source and gained a surface you can read
    * the size of the room from.
    */
-  color: z.string().default('#241e19'),
+  color: z.string().default('#241e19').describe('color'),
   /**
    * Width of one poured slab, in world units. 0 leaves the floor unseamed.
    *
@@ -93,7 +93,7 @@ export const stageSuspensionSchema = z.object({
    * paper is meant to be impossible.
    */
   type: z.enum(['none', 'thread', 'rod']).default('thread'),
-  color: z.string().default('#9c948a'),
+  color: z.string().default('#9c948a').describe('color'),
   /**
    * What grips the sheet.
    *
@@ -149,7 +149,7 @@ export const stageColumnsSchema = z.object({
    * more banners, and the eye stops being able to tell what the room is made
    * of from what is hanging in it.
    */
-  color: z.string().default('#5c554d'),
+  color: z.string().default('#5c554d').describe('color'),
 })
 
 /**
@@ -168,7 +168,7 @@ export const stageDoorwaySchema = z.object({
   enabled: z.boolean().default(false),
   /** Opening size, as a multiple of the source's own. 1 frames it exactly. */
   opening: z.number().min(0.2).max(3).default(1.05),
-  color: z.string().default('#171310'),
+  color: z.string().default('#171310').describe('color'),
 })
 
 export const stageRoomSchema = z.object({
@@ -182,7 +182,7 @@ export const stageRoomSchema = z.object({
    * happened to be scaled to that day.
    */
   height: z.number().min(1).max(6).default(2.2),
-  color: z.string().default('#171310'),
+  color: z.string().default('#171310').describe('color'),
   /** Columns flanking the walk — see `stageColumnsSchema`. */
   columns: stageColumnsSchema.default({}),
   /** A wall at the end of the walk with the source in it. */


### PR DESCRIPTION
Stacked on #56 → #55 → #54 → #53 → #52.

Three things: real colour pickers, the stage's light panel in all three modes, and the background image — the last item from the original list, which I had been flagging instead of building.

## 1 · Colours are pickers now

Twelve fields across content, wash, light and the stage were `z.string()`, so all twelve drew as text boxes you had to type hex into. Now: **a swatch and a hex field side by side.** The swatch is how you find a colour you have not decided on; the field is how you paste one from your palette and read back what the swatch gave you.

Marked with `.describe('color')` rather than guessed from field names — `color` and `secondary` are both pigments, `font` and `text` are both not, and no rule over names separates them. One trap: `.describe()` attaches to whatever it was called on, so after `.default()` it never reaches the string. The walk reads both, tested for `.default()` and `.optional()` placement.

**The swatch is throttled.** A native picker fires continuously while you drag, and on a content colour every event repaints the sheet's texture — the cost that made text commit on blur. Events are spent at a rate the canvas keeps up with, and the value you release on always commits.

## 2 · The light panel, in all three modes

Stage could be *"nave, but the sun is lower"*. A lone sheet could only be one of seven rigs exactly as shipped — even though `<PaperLighting>` had accepted these overrides all along and nothing passed them. `scene.light` joins `scene.lighting`, and the stage panel becomes everyone's.

`lightSchema` moves into `config/schema.ts` — `sceneSchema` needs it and `lighting.ts` imports *from* the schema, so the dependency could not run the other way. Re-exported from its old home.

## 3 · The backdrop

`scene.backdrop` — a colour and a picture behind the sheet, with `fade` and `blur` so a backdrop stays a backdrop. A photograph at full strength competes with the paper in front of it, which is what a photographer solves by putting the background out of the light.

**In the config, not the editor** — that was the open question, and the answer is the one this repo keeps giving: the export story is that the code you copy makes the picture you were looking at. A backdrop that lived only in the editor would make the most-photographed part of a composition the one thing that does not travel.

Optional, so an unset backdrop leaves the canvas exactly as found — `<Paper>` has always rendered onto whatever is behind it, and a default that painted the frame would change every sheet already on a page.

Painted onto a canvas at the viewport's size rather than assigned straight to `scene.background`: three stretches a background texture to the frame whatever shape it is, so a landscape photo behind a 9:16 export would come out squashed — and the export sizes are exactly where a backdrop earns its keep. `<PaperMesh>` deliberately does *not* render one; it drops into someone else's scene.

## Bugs this turned up

**`diffConfig` threw away everything in a scene except `lighting`.** It read `if (scene.lighting !== 'studio') out.scene = { lighting }` — true while `lighting` was the only field, and it silently discarded everything added beside it. So the light overrides from part 2 were shown by the editor and carried by **nothing that left it**: not a `.paper` file, not a share link, not a snippet, not an agent payload. Found only because the backdrop vanished from an export the same way. Diffed properly now, with a round-trip test.

**Code exports pasted uploaded pictures into source as base64** — already true of an uploaded sheet image before backdrops existed. Snippets get a numbered path and a line saying so; `.paper` files and share links still carry the real bytes, because a file has room and dropping them there would lose the artwork rather than reformat it.

**Field lighting came from whichever preset sat in slot 1**, so swapping one card relit the gallery. **`<PaperField>` lit itself with a bare ambient + directional** while the editor previewed it through `<PaperLighting>` — the gallery you composed and the code you exported were two different pictures. **`<Paper>` never passed `scene.light`** to its own rig. **`diffFieldProps` compared by reference**, so an array-valued layout option equal to its default exported a prop saying what the default already said.

## Verification

`lint` · `typecheck` · `knip` clean. **797 tests pass** (20 new). `pnpm test:share` still passes.

In a browser, all three modes: light resolves and drives the render, reset appears once touched, swatch and hex track each other; the backdrop renders in Paper and Field and survives into the JSX export as a path with a warning and no base64; Share correctly refuses a paper carrying a backdrop upload and names the reason; the field export emits `scene={…}` naming the rig it is previewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)