### PR TITLE
fix(editor): the option list closed on its own scroll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,11 @@ jobs:
       # the pipeline type-checks or renders that file, so check it directly.
       - name: Root routing gate
         run: pnpm test:route
+
+      # The select is the app's own, so its option list is app DOM in a
+      # scrolling box. It shipped dismissing itself on its own scroll, which
+      # put every option below the fold out of reach of a mouse with nothing
+      # in the console to say so. Only a browser can tell whether the whole
+      # list is reachable.
+      - name: Dropdown reach gate
+        run: pnpm test:dropdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,6 +433,7 @@ pnpm knip           # dead code and unused exports
 | `pnpm test:parity` | `parity.html` | every deformer's GLSL twin vs its JS twin. **CI gate** |
 | `pnpm test:drive` | the editor | the stage really walks when you drag, wheel or arrow it. **CI gate** |
 | `pnpm test:share` | the editor | sculpt → copy a link → open it in a browser that has never seen the paper. **CI gate** |
+| `pnpm test:dropdown` | the editor | every option list is reachable — including the ones below the fold. **CI gate** |
 | `pnpm perf` / `perf:field` | `stage.html` / `field.html` | frame cost. `--gpu` for the platform GPU, `--soft` for the SwiftShader floor |
 | `pnpm shot` / `shot:ui` / `shot:play` / `shot:light` | stage, editor, playground, one rig | PNGs into `.shots/` |
 | `pnpm media` | `media.html` | the README's GIFs and MP4s, stepped frame-exact |

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ pnpm test           # 700+ unit tests — deformer math, schema, cloth, layouts,
 pnpm test:parity    # 37 golden-vector cases: every deformer's GLSL twin vs its JS twin
 pnpm test:drive     # the stage really walks when you drag, wheel or arrow it
 pnpm test:share     # sculpt → link → a browser that has never seen the paper
+pnpm test:dropdown  # every dropdown option is reachable, including below the fold
 pnpm typecheck
 pnpm lint
 pnpm knip           # dead code and unused exports

--- a/apps/editor/src/controls/Select.tsx
+++ b/apps/editor/src/controls/Select.tsx
@@ -42,6 +42,7 @@ export function Select({ value, options, onChange, label, className, format, tit
   const [open, setOpen] = useState(false)
   const [active, setActive] = useState(() => Math.max(0, options.indexOf(value)))
   const triggerRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
   const listId = useId()
   const show = (option: string) => format?.(option) ?? option
 
@@ -64,9 +65,18 @@ export function Select({ value, options, onChange, label, className, format, tit
   // moves the trigger afterwards — scrolling the rail it lives in, resizing
   // the window — would leave the list floating somewhere it no longer
   // belongs, so those close it rather than chasing it.
+  //
+  // Scrolling *inside* the list is the exact opposite: the trigger has not
+  // moved, and the user is reading options that do not fit. This listener is
+  // on capture, so it hears that scroll too — and closing on it made every
+  // option past the fold unreachable with a mouse, silently, because the
+  // list vanished the moment you reached for the ones you could not see.
   useEffect(() => {
     if (!open) return
-    const close = () => setOpen(false)
+    const close = (e: Event) => {
+      if (e.target instanceof Node && listRef.current?.contains(e.target)) return
+      setOpen(false)
+    }
     window.addEventListener('scroll', close, true)
     window.addEventListener('resize', close)
     return () => {
@@ -144,6 +154,7 @@ export function Select({ value, options, onChange, label, className, format, tit
           id={listId}
           label={label}
           anchor={triggerRef.current}
+          listRef={listRef}
           options={options}
           value={value}
           active={active}
@@ -165,6 +176,7 @@ interface SelectListProps {
   id: string
   label: string
   anchor: HTMLElement | null
+  listRef: React.RefObject<HTMLDivElement | null>
   options: readonly string[]
   value: string
   active: number
@@ -179,6 +191,7 @@ function SelectList({
   id,
   label,
   anchor,
+  listRef: ref,
   options,
   value,
   active,
@@ -188,7 +201,6 @@ function SelectList({
   onDismiss,
   onKeyDown,
 }: SelectListProps) {
-  const ref = useRef<HTMLDivElement>(null)
   const [box, setBox] = useState<{ top: number; left: number; width: number; max: number } | null>(null)
 
   // Measure before paint: a list that renders at 0,0 and then jumps is worse
@@ -210,6 +222,7 @@ function SelectList({
 
   // Focus moves into the list so the arrows keep working after the mouse
   // opened it; dismissing puts focus back on the trigger.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: on mount only — the list is unmounted when it closes, so "once, when it appears" is the whole intent.
   useEffect(() => {
     ref.current?.focus()
   }, [])

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "media": "node tools/media.mjs",
     "test:share": "node tools/share-loop-check.mjs",
     "test:route": "node tools/route-check.mjs",
+    "test:dropdown": "node tools/dropdown-check.mjs",
     "test:drive": "node tools/stage-drive-check.mjs",
     "shot:light": "node tools/catalogue-shot.mjs --vary=lighting --all",
     "shot:catalogue": "node tools/catalogue-shot.mjs",

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -221,6 +221,7 @@ pnpm test           # 700+ unit tests — deformer math, schema, cloth, layouts,
 pnpm test:parity    # 37 golden-vector cases: every deformer's GLSL twin vs its JS twin
 pnpm test:drive     # the stage really walks when you drag, wheel or arrow it
 pnpm test:share     # sculpt → link → a browser that has never seen the paper
+pnpm test:dropdown  # every dropdown option is reachable, including below the fold
 pnpm typecheck
 pnpm lint
 pnpm knip           # dead code and unused exports

--- a/tools/dropdown-check.mjs
+++ b/tools/dropdown-check.mjs
@@ -10,11 +10,20 @@
  * the list vanished, with nothing in the console to say why. Whether the
  * whole list is reachable is exactly what a unit test cannot see and a
  * screenshot does not try, so drive it.
+ *
+ * Everything here waits on a condition rather than a duration. Choosing a
+ * preset rebuilds a canvas, and on CI that canvas is SwiftShader on a shared
+ * runner — the same click that settles instantly on a laptop can take fifteen
+ * seconds there. A sleep long enough to cover that is either flaky or slow,
+ * and the first draft of this file was both.
  */
 import { chromium } from 'playwright'
 import { startApp } from './harness.mjs'
 
 const PORT = 5206
+/** One interaction's worth of patience, generous enough for a cold CI runner. */
+const SETTLE = 20_000
+
 const { base, stop } = await startApp('editor', PORT)
 
 const results = []
@@ -30,36 +39,75 @@ try {
   page.on('pageerror', (e) => problems.push(String(e)))
   page.on('console', (m) => m.type() === 'error' && problems.push(m.text()))
   await page.goto(base, { waitUntil: 'networkidle' })
-  await page.waitForTimeout(2500)
-  const gotIt = page.getByRole('button', { name: 'Got it' })
-  if (await gotIt.isVisible().catch(() => false)) await gotIt.click()
 
   const list = page.locator('.select-list')
   const isOpen = async () => (await list.count()) > 0
-  const dismiss = async () => {
-    if (await isOpen()) await page.keyboard.press('Escape').catch(() => {})
-    await page.waitForTimeout(200)
+
+  const gotIt = page.getByRole('button', { name: 'Got it' })
+  await gotIt.click({ timeout: SETTLE }).catch(() => {})
+
+  /** Click a trigger and wait for its list, rather than for a guessed delay. */
+  const openList = async (trigger) => {
+    await trigger.scrollIntoViewIfNeeded().catch(() => {})
+    await trigger.click({ timeout: SETTLE }).catch(() => {})
+    return await list
+      .first()
+      .waitFor({ state: 'attached', timeout: SETTLE })
+      .then(() => true)
+      .catch(() => false)
   }
 
-  // Every mode has its own rails, and the long lists are spread across them.
-  for (const mode of ['Paper', 'Field', 'Stage']) {
-    await page.getByRole('button', { name: mode, exact: true }).click()
-    await page.waitForTimeout(2200)
+  const dismiss = async () => {
+    if (!(await isOpen())) return
+    await page.keyboard.press('Escape').catch(() => {})
+    await list
+      .first()
+      .waitFor({ state: 'detached', timeout: SETTLE })
+      .catch(() => {})
+  }
 
+  /**
+   * Which dropdowns each mode is asked about. The field composer builds one
+   * identical picker per slot; driving all fourteen re-renders the canvas
+   * fourteen times to re-test one component, which is how this gate came to
+   * take eight minutes. Two instances prove the wiring, and the schema-driven
+   * pickers in the other modes cover the rest.
+   */
+  const MODES = [
+    { mode: 'Paper', only: null },
+    { mode: 'Field', only: ['Paper 1 preset', 'type'] },
+    { mode: 'Stage', only: null },
+  ]
+
+  for (const { mode, only } of MODES) {
+    await page.getByRole('button', { name: mode, exact: true }).click({ timeout: SETTLE })
+
+    // The rails for this mode have to exist before anything can be clicked,
+    // and on a cold runner they do not arrive on the same tick as the click.
     const triggers = page.getByRole('combobox')
+    await page
+      .waitForFunction(() => document.querySelectorAll('[role=combobox]').length > 0, null, {
+        timeout: SETTLE,
+      })
+      .catch(() => {})
+    await triggers
+      .first()
+      .waitFor({ state: 'visible', timeout: SETTLE })
+      .catch(() => {})
+
     const names = await triggers.evaluateAll((els) => els.map((e) => e.getAttribute('aria-label')))
     check(`${mode} has dropdowns to check`, names.length > 0, `${names.length} found`)
 
     for (let i = 0; i < names.length; i++) {
+      if (only && !only.includes(names[i])) continue
       await dismiss()
       // Choosing an option re-renders the panel, and in the field composer it
       // can change which rows exist at all — so re-check that this trigger is
-      // still on the page rather than waiting 30s for one that has gone.
+      // still on the page rather than waiting on one that has gone.
       if ((await triggers.count()) <= i) break
       const trigger = triggers.nth(i)
-      await trigger.scrollIntoViewIfNeeded().catch(() => {})
-      await trigger.click({ timeout: 5000 }).catch(() => {})
-      if (!(await isOpen())) {
+
+      if (!(await openList(trigger))) {
         check(`${mode} > ${names[i]} opens`, false)
         continue
       }
@@ -76,24 +124,37 @@ try {
       // The list fits — there is nothing below the fold to be cut off from.
       if (!box.overflows) continue
 
-      // Reading past the fold is the thing that used to dismiss it.
+      // Reading past the fold is the thing that used to dismiss it. Give the
+      // wheel a moment to be acted on, then ask whether the list is still up.
       const bb = await list.first().boundingBox()
       await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2)
       await page.mouse.wheel(0, 250)
-      await page.waitForTimeout(350)
-      const survived = await isOpen()
+      const survived = await list
+        .first()
+        .waitFor({ state: 'detached', timeout: 1500 })
+        .then(() => false)
+        .catch(() => true)
       check(`${mode} > ${names[i]} survives scrolling its own list`, survived)
       if (!survived) continue
 
-      // And the option you scrolled to must still be selectable.
+      // And the option you scrolled to must still be selectable. Wait for the
+      // trigger to actually say so — committing a preset rebuilds the canvas.
       const last = list.first().locator('.select-option').last()
       const wanted = (await last.textContent())?.trim()
-      await last.click({ timeout: 4000 }).catch(() => {})
-      await page.waitForTimeout(500)
-      const now = await trigger.textContent({ timeout: 4000 }).catch(() => null)
-      // A trigger that re-rendered itself out of existence answers the
-      // question too: the click landed, which is all this is asking.
-      const picked = now === null || (wanted !== undefined && now.includes(wanted))
+      await last.click({ timeout: SETTLE }).catch(() => {})
+      const picked = await page
+        .waitForFunction(
+          ({ label, want }) => {
+            const el = document.querySelector(`[role=combobox][aria-label="${label}"]`)
+            // A trigger that re-rendered itself out of existence answers the
+            // question too: the click landed, which is all this is asking.
+            return el === null || (el.textContent ?? '').includes(want)
+          },
+          { label: names[i], want: wanted ?? '' },
+          { timeout: SETTLE },
+        )
+        .then(() => true)
+        .catch(() => false)
       check(`${mode} > ${names[i]} can pick its last option`, picked, `wanted "${wanted}"`)
     }
     await dismiss()
@@ -102,23 +163,32 @@ try {
   // The behaviour the dismissal exists for must survive the fix: the popup is
   // positioned off a rect captured once, so a rail that scrolls under it has
   // to close it rather than let it drift off its trigger.
-  await page.getByRole('button', { name: 'Paper', exact: true }).click()
-  await page.waitForTimeout(2000)
-  await page.getByRole('combobox', { name: 'Choose a built-in preset' }).click()
-  await page.waitForTimeout(300)
-  const openedForDrift = await isOpen()
-  await page.evaluate(() => {
-    document.querySelector('aside')?.dispatchEvent(new Event('scroll', { bubbles: false }))
-  })
-  await page.waitForTimeout(350)
-  check('an outside scroll still dismisses it', openedForDrift && !(await isOpen()))
+  await page.getByRole('button', { name: 'Paper', exact: true }).click({ timeout: SETTLE })
+  const presetPicker = page.getByRole('combobox', { name: 'Choose a built-in preset' })
+  await presetPicker.waitFor({ state: 'visible', timeout: SETTLE })
 
-  await page.getByRole('combobox', { name: 'Choose a built-in preset' }).click()
-  await page.waitForTimeout(300)
-  const openedForResize = await isOpen()
-  await page.setViewportSize({ width: 1500, height: 950 })
-  await page.waitForTimeout(450)
-  check('a resize still dismisses it', openedForResize && !(await isOpen()))
+  const closedBy = async (act) => {
+    if (!(await openList(presetPicker))) return false
+    await act()
+    return await list
+      .first()
+      .waitFor({ state: 'detached', timeout: SETTLE })
+      .then(() => true)
+      .catch(() => false)
+  }
+
+  check(
+    'an outside scroll still dismisses it',
+    await closedBy(() =>
+      page.evaluate(() => {
+        document.querySelector('aside')?.dispatchEvent(new Event('scroll', { bubbles: false }))
+      }),
+    ),
+  )
+  check(
+    'a resize still dismisses it',
+    await closedBy(() => page.setViewportSize({ width: 1500, height: 950 })),
+  )
 } finally {
   await browser.close()
   stop()

--- a/tools/dropdown-check.mjs
+++ b/tools/dropdown-check.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Opens every dropdown in the editor and tries to reach the options that do
+ * not fit. Run: `pnpm test:dropdown`.
+ *
+ * The select is the app's own, so the option list is app DOM in a scrolling
+ * box rather than an OS popup — and it shipped closing itself on any `scroll`
+ * event, including its own. Sixteen presets in a 260px list meant the seven
+ * below the fold could not be reached with a mouse at all: reach for them and
+ * the list vanished, with nothing in the console to say why. Whether the
+ * whole list is reachable is exactly what a unit test cannot see and a
+ * screenshot does not try, so drive it.
+ */
+import { chromium } from 'playwright'
+import { startApp } from './harness.mjs'
+
+const PORT = 5206
+const { base, stop } = await startApp('editor', PORT)
+
+const results = []
+const check = (name, pass, detail = '') => {
+  results.push({ name, pass })
+  console.log(`${pass ? '+' : 'x'} ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+const browser = await chromium.launch()
+const problems = []
+try {
+  const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } })
+  page.on('pageerror', (e) => problems.push(String(e)))
+  page.on('console', (m) => m.type() === 'error' && problems.push(m.text()))
+  await page.goto(base, { waitUntil: 'networkidle' })
+  await page.waitForTimeout(2500)
+  const gotIt = page.getByRole('button', { name: 'Got it' })
+  if (await gotIt.isVisible().catch(() => false)) await gotIt.click()
+
+  const list = page.locator('.select-list')
+  const isOpen = async () => (await list.count()) > 0
+  const dismiss = async () => {
+    if (await isOpen()) await page.keyboard.press('Escape').catch(() => {})
+    await page.waitForTimeout(200)
+  }
+
+  // Every mode has its own rails, and the long lists are spread across them.
+  for (const mode of ['Paper', 'Field', 'Stage']) {
+    await page.getByRole('button', { name: mode, exact: true }).click()
+    await page.waitForTimeout(2200)
+
+    const triggers = page.getByRole('combobox')
+    const names = await triggers.evaluateAll((els) => els.map((e) => e.getAttribute('aria-label')))
+    check(`${mode} has dropdowns to check`, names.length > 0, `${names.length} found`)
+
+    for (let i = 0; i < names.length; i++) {
+      await dismiss()
+      // Choosing an option re-renders the panel, and in the field composer it
+      // can change which rows exist at all — so re-check that this trigger is
+      // still on the page rather than waiting 30s for one that has gone.
+      if ((await triggers.count()) <= i) break
+      const trigger = triggers.nth(i)
+      await trigger.scrollIntoViewIfNeeded().catch(() => {})
+      await trigger.click({ timeout: 5000 }).catch(() => {})
+      if (!(await isOpen())) {
+        check(`${mode} > ${names[i]} opens`, false)
+        continue
+      }
+
+      const box = await list.first().evaluate((el) => {
+        const r = el.getBoundingClientRect()
+        return {
+          overflows: el.scrollHeight > el.clientHeight + 1,
+          onScreen: r.top >= 0 && r.bottom <= window.innerHeight && r.right <= window.innerWidth,
+        }
+      })
+      check(`${mode} > ${names[i]} opens on screen`, box.onScreen)
+
+      // The list fits — there is nothing below the fold to be cut off from.
+      if (!box.overflows) continue
+
+      // Reading past the fold is the thing that used to dismiss it.
+      const bb = await list.first().boundingBox()
+      await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2)
+      await page.mouse.wheel(0, 250)
+      await page.waitForTimeout(350)
+      const survived = await isOpen()
+      check(`${mode} > ${names[i]} survives scrolling its own list`, survived)
+      if (!survived) continue
+
+      // And the option you scrolled to must still be selectable.
+      const last = list.first().locator('.select-option').last()
+      const wanted = (await last.textContent())?.trim()
+      await last.click({ timeout: 4000 }).catch(() => {})
+      await page.waitForTimeout(500)
+      const now = await trigger.textContent({ timeout: 4000 }).catch(() => null)
+      // A trigger that re-rendered itself out of existence answers the
+      // question too: the click landed, which is all this is asking.
+      const picked = now === null || (wanted !== undefined && now.includes(wanted))
+      check(`${mode} > ${names[i]} can pick its last option`, picked, `wanted "${wanted}"`)
+    }
+    await dismiss()
+  }
+
+  // The behaviour the dismissal exists for must survive the fix: the popup is
+  // positioned off a rect captured once, so a rail that scrolls under it has
+  // to close it rather than let it drift off its trigger.
+  await page.getByRole('button', { name: 'Paper', exact: true }).click()
+  await page.waitForTimeout(2000)
+  await page.getByRole('combobox', { name: 'Choose a built-in preset' }).click()
+  await page.waitForTimeout(300)
+  const openedForDrift = await isOpen()
+  await page.evaluate(() => {
+    document.querySelector('aside')?.dispatchEvent(new Event('scroll', { bubbles: false }))
+  })
+  await page.waitForTimeout(350)
+  check('an outside scroll still dismisses it', openedForDrift && !(await isOpen()))
+
+  await page.getByRole('combobox', { name: 'Choose a built-in preset' }).click()
+  await page.waitForTimeout(300)
+  const openedForResize = await isOpen()
+  await page.setViewportSize({ width: 1500, height: 950 })
+  await page.waitForTimeout(450)
+  check('a resize still dismisses it', openedForResize && !(await isOpen()))
+} finally {
+  await browser.close()
+  stop()
+}
+
+if (problems.length) {
+  console.error(`\nconsole errors (${problems.length}):`)
+  for (const p of problems.slice(0, 8)) console.error(`  ${p}`)
+}
+const failed = results.filter((r) => !r.pass)
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`)
+process.exitCode = failed.length || problems.length ? 1 : 0


### PR DESCRIPTION
Reported after the launch post: "the preset dropdown doesn't work — it works only on my laptop." It was not the preset dropdown, and it was not the laptop.

## What was wrong

The select is the app's own, so the option list is app DOM in a scrolling box rather than an OS popup. It is portaled to `<body>` and positioned off a rect captured once, so it closes on scroll and resize rather than drifting away from the trigger it belongs to. That listener was registered on the **capture phase**:

```js
window.addEventListener('scroll', close, true)
```

Capture means it also heard the scroll events the list emits about *itself*. The list caps at 260px; sixteen presets is 408px of options. So roughly nine were visible and seven sat below the fold — and reaching for them dismissed the list, every time.

Nothing threw, so the console said nothing. It reads as "the dropdown just doesn't work", and only for people who scroll it: anyone who did not already know their preset was in the visible top third. That is the whole "works on my machine" — it works fine if you only ever click the first few.

## It was 18 dropdowns, not one

| Mode | Dropdown | Options | Broken |
|---|---|---|---|
| Paper | Choose a built-in preset | 16 | yes |
| Paper | type | 13 | yes |
| Field | Paper 1–14 preset | 16 each | yes, all fourteen |
| Field | type | 12 | yes |
| Stage | layout | 12 | yes |
| Stage | source, shape ×2, preset, quality | 2–8 | no — they fit |

The six that worked were not fixed. They were short enough that no scrollbar ever appeared.

## The fix

Ignore scrolls that originate inside the list: the trigger has not moved, the user is reading options that do not fit. Outside scrolls and resizes still dismiss, which is the behaviour the listener was added for, and both are asserted.

## The gate

This shipped, went out to a launch, and was invisible to every check in the pipeline — unit tests cannot see it and screenshots do not try. So `pnpm test:dropdown` joins the other harnesses that exist for things which fail in silence. It opens every dropdown in every mode, scrolls the ones that overflow, and asserts the last option is still reachable and clickable.

Verified it bites: reverting the fix drops it from **64/64 to 28/46**.

## Checks

`lint`, `typecheck`, `test`, `knip`, `build`, `test:dropdown` all green. Zero console or page errors across every browser run.

No changeset — `@paperlab/editor` is private; the published `paperlab` package is untouched.

## One thing left for you

Not changed here, because it is a design call rather than a defect: on a *closed* select, ArrowUp/Home/End commit a new value immediately, but ArrowDown opens the list instead ([`Select.tsx:99-108`](https://github.com/NourMtir0722/Paperlab/blob/fix/dropdown-closes-on-own-scroll/apps/editor/src/controls/Select.tsx#L99-L108)) — while the comment above describes commit-directly as the behaviour for all the arrows. Worth picking one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown menus remain open while scrolling within their option lists, allowing options below the fold to be reached.
  * Dropdowns still dismiss correctly when scrolling outside the menu or resizing the viewport.

* **Tests**
  * Added browser-based checks covering dropdown visibility, scrolling, selection of the last option, and dismissal behavior.

* **Documentation**
  * Documented the new dropdown verification command and included it among the project’s CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->