### PR TITLE
fix(editor): one keyboard rule for the select, and a listbox you can reach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,7 @@ pnpm knip           # dead code and unused exports
 | `pnpm test:drive` | the editor | the stage really walks when you drag, wheel or arrow it. **CI gate** |
 | `pnpm test:share` | the editor | sculpt → copy a link → open it in a browser that has never seen the paper. **CI gate** |
 | `pnpm test:dropdown` | the editor | every option list is reachable — including the ones below the fold. **CI gate** |
+| `pnpm test:route` | `tools/site-root.html` | the site root sends desktops to the editor and everything else to the playground. **CI gate** |
 | `pnpm perf` / `perf:field` | `stage.html` / `field.html` | frame cost. `--gpu` for the platform GPU, `--soft` for the SwiftShader floor |
 | `pnpm shot` / `shot:ui` / `shot:play` / `shot:light` | stage, editor, playground, one rig | PNGs into `.shots/` |
 | `pnpm media` | `media.html` | the README's GIFs and MP4s, stepped frame-exact |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ And it is navigable rather than a video. It drifts on its own until you touch it
 - **Physics** — curated idle motion (`float`, `tumble`, `dangle`, `taped`, `breeze`) that composes with behaviors, and a verlet **cloth** mode: pin the top edge, add wind, grab the sheet and pull. Cloth and behaviors are mutually exclusive by schema — cloth owns the vertices.
 - **Interaction states** — a preset can carry `states`: overrides-on-base diffs keyed `rest` / `hover` / `pressed` / `picked` / `placed`, with the triggers built in. Drag a stamp past its threshold and it tears off its sheet (the perforation edges facing its neighbours flip to torn), release it over a `<DropZone>` and it settles, release it anywhere else and it flutters home. The whole flow is reachable from the keyboard: focus a paper, Enter picks, arrows move between zones, Enter places, Escape returns it.
 - **Hardware that holds the paper up** — thread to the ceiling or a rod across the top edge, gripped by a clip or a peg. A hung thing that shows what holds it stops reading as a rectangle that happens to float.
-- **Presets** — 15 paper presets and 6 stage presets, and everything serializes to `.paper` JSON validated by a zod schema. Diffable, forkable, shareable.
+- **Presets** — 16 paper presets and 6 stage presets, and everything serializes to `.paper` JSON validated by a zod schema. Diffable, forkable, shareable.
 - **Agent-first export** — the editor's **Copy for AI** button produces a self-contained brief you paste into a coding agent: install line, inlined component, placement contract, and a verification step the agent can self-check. See [AGENTS.md](AGENTS.md) and [docs/llms.txt](docs/llms.txt).
 - **Accessible by default** — `prefers-reduced-motion` freezes behaviors at their pose and disables physics and entrances, a hidden DOM mirror carries the content for screen readers and find-in-page, and a flat DOM fallback renders when WebGL isn't available.
 
@@ -229,7 +229,7 @@ pnpm knip           # dead code and unused exports
 pnpm build
 ```
 
-Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All four test commands are CI gates, along with `publint` and `are-the-types-wrong` on the published package.
+Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All six test commands are CI gates, along with `publint` and `are-the-types-wrong` on the published package.
 
 ### Measurement
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ pnpm test:parity    # 37 golden-vector cases: every deformer's GLSL twin vs its 
 pnpm test:drive     # the stage really walks when you drag, wheel or arrow it
 pnpm test:share     # sculpt → link → a browser that has never seen the paper
 pnpm test:dropdown  # every dropdown option is reachable, including below the fold
+pnpm test:route     # the site root sends each device to the app built for it
 pnpm typecheck
 pnpm lint
 pnpm knip           # dead code and unused exports

--- a/apps/editor/src/controls/Select.tsx
+++ b/apps/editor/src/controls/Select.tsx
@@ -11,10 +11,17 @@ import { createPortal } from 'react-dom'
  *
  * Two things it must not lose by leaving the native control behind:
  *
- * - **Keyboard.** Enter / Space / ArrowDown open, arrows and Home/End move,
- *   Enter or Space commit, Escape and Tab close, and typing letters jumps to
- *   the next matching option. That is the native contract, and this is the
- *   whole cost of replacing a native control.
+ * - **Keyboard.** One rule: a navigation key *names* an option. Closed, that
+ *   opens the list on it; open, it moves the highlight to it. Arrows, Home,
+ *   End and typeahead all work that way, and nothing changes the value until
+ *   Enter, Space or a click says so. Escape and Tab close.
+ *
+ *   This is the ARIA select-only combobox pattern, which is the contract the
+ *   widget opted into the moment it claimed `role="combobox"` over a
+ *   `role="listbox"`. It replaced a split where ArrowDown opened but ArrowUp,
+ *   Home and End committed on the spot — so Home on a closed picker silently
+ *   swapped the sculpt for the first preset and rebuilt the canvas, with no
+ *   list ever shown and nothing asked.
  * - **Not being clipped.** Both inspector rails are `overflow-y: auto`, so a
  *   popup positioned inside one is cut off by it. The list is therefore
  *   portaled to `<body>` and positioned `fixed` off the trigger's rect —
@@ -87,19 +94,18 @@ export function Select({ value, options, onChange, label, className, format, tit
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     const index = open ? active : Math.max(0, options.indexOf(value))
+    // Every key below names an option. Closed, that opens the list on it
+    // rather than committing it: choosing a preset rebuilds the canvas, and
+    // no keystroke should do that without the list ever being seen.
     const move = (next: number) => {
       e.preventDefault()
       const clamped = Math.min(options.length - 1, Math.max(0, next))
       if (open) setActive(clamped)
-      // Closed, the arrows step the value directly, the way a native select
-      // does on every platform this app runs on.
-      else commit(clamped)
+      else openList(clamped)
     }
     switch (e.key) {
       case 'ArrowDown':
-        if (open) return move(index + 1)
-        e.preventDefault()
-        return openList(index)
+        return move(index + 1)
       case 'ArrowUp':
         return move(index - 1)
       case 'Home':
@@ -222,10 +228,15 @@ function SelectList({
 
   // Focus moves into the list so the arrows keep working after the mouse
   // opened it; dismissing puts focus back on the trigger.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: on mount only — the list is unmounted when it closes, so "once, when it appears" is the whole intent.
+  //
+  // It has to wait for the measurement. Until `box` lands the list is still
+  // `visibility: hidden`, and a hidden element cannot take focus — so the
+  // version of this that ran on mount called `focus()` into the void and left
+  // the listbox unreachable to anything that follows focus.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the measurement is the trigger — the list is reached through the DOM rather than by closing over it, and `box` lands once per open.
   useEffect(() => {
-    ref.current?.focus()
-  }, [])
+    if (box) ref.current?.focus()
+  }, [box])
 
   // Keep the active option in view for arrow-key and typeahead travel.
   // biome-ignore lint/correctness/useExhaustiveDependencies: `active` is the whole trigger — the effect re-runs to scroll the newly-active option into view, and reads it through the DOM rather than by closing over it.
@@ -251,6 +262,12 @@ function SelectList({
         }
         onKeyDown={onKeyDown}
       >
+        {/* `mousemove`, not `mouseenter`: the list opens under wherever the
+            cursor already was, and `mouseenter` fires on an option that
+            appears beneath a stationary pointer. That let the mouse overrule
+            the key that opened the list — press End, and the highlight landed
+            on whatever happened to be under your hand instead of on the last
+            option. Hover should follow the hand, and only when it moves. */}
         {options.map((option, i) => (
           <button
             key={option}
@@ -259,7 +276,7 @@ function SelectList({
             aria-selected={option === value}
             data-active={i === active}
             className={`select-option${option === value ? ' selected' : ''}${i === active ? ' active' : ''}`}
-            onMouseEnter={() => onHover(i)}
+            onMouseMove={() => onHover(i)}
             onClick={() => onPick(i)}
           >
             {show(option)}

--- a/apps/editor/src/panels/presetCounts.test.ts
+++ b/apps/editor/src/panels/presetCounts.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { listPresets } from 'paperlab'
+import { listStagePresets } from 'paperlab/stage'
+
+/**
+ * The README counts its own presets, and nothing checked the number.
+ *
+ * It claimed fifteen paper presets while the library shipped sixteen. That
+ * file is the npm page — generated into the published tarball and frozen
+ * there — so a wrong number outlives the release that introduced it. Adding a
+ * preset is the moment the sentence goes stale, and adding a preset is
+ * exactly when nobody is re-reading prose.
+ *
+ * Same argument as the generated-README gate: a claim nothing verifies is a
+ * claim that drifts. It lives here rather than in the library because the
+ * library has no `@types/node` on purpose, and this needs to read a file.
+ */
+const README = resolve(import.meta.dirname, '../../../../README.md')
+
+describe('the README counts', () => {
+  it('states the number of presets the library actually has', () => {
+    const readme = readFileSync(README, 'utf8')
+    const claim = readme.match(/(\d+) paper presets and (\d+) stage presets/)
+    expect(claim, 'the README no longer states its preset counts — update this test with it').not.toBeNull()
+
+    const [, paper, stage] = claim as RegExpMatchArray
+    expect(
+      { paper: Number(paper), stage: Number(stage) },
+      `README.md says "${claim?.[0]}" — fix it, then \`pnpm build\` to regenerate packages/paperlab/README.md`,
+    ).toEqual({ paper: listPresets().length, stage: listStagePresets().length })
+  })
+})

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -222,6 +222,7 @@ pnpm test:parity    # 37 golden-vector cases: every deformer's GLSL twin vs its 
 pnpm test:drive     # the stage really walks when you drag, wheel or arrow it
 pnpm test:share     # sculpt → link → a browser that has never seen the paper
 pnpm test:dropdown  # every dropdown option is reachable, including below the fold
+pnpm test:route     # the site root sends each device to the app built for it
 pnpm typecheck
 pnpm lint
 pnpm knip           # dead code and unused exports

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -144,7 +144,7 @@ And it is navigable rather than a video. It drifts on its own until you touch it
 - **Physics** — curated idle motion (`float`, `tumble`, `dangle`, `taped`, `breeze`) that composes with behaviors, and a verlet **cloth** mode: pin the top edge, add wind, grab the sheet and pull. Cloth and behaviors are mutually exclusive by schema — cloth owns the vertices.
 - **Interaction states** — a preset can carry `states`: overrides-on-base diffs keyed `rest` / `hover` / `pressed` / `picked` / `placed`, with the triggers built in. Drag a stamp past its threshold and it tears off its sheet (the perforation edges facing its neighbours flip to torn), release it over a `<DropZone>` and it settles, release it anywhere else and it flutters home. The whole flow is reachable from the keyboard: focus a paper, Enter picks, arrows move between zones, Enter places, Escape returns it.
 - **Hardware that holds the paper up** — thread to the ceiling or a rod across the top edge, gripped by a clip or a peg. A hung thing that shows what holds it stops reading as a rectangle that happens to float.
-- **Presets** — 15 paper presets and 6 stage presets, and everything serializes to `.paper` JSON validated by a zod schema. Diffable, forkable, shareable.
+- **Presets** — 16 paper presets and 6 stage presets, and everything serializes to `.paper` JSON validated by a zod schema. Diffable, forkable, shareable.
 - **Agent-first export** — the editor's **Copy for AI** button produces a self-contained brief you paste into a coding agent: install line, inlined component, placement contract, and a verification step the agent can self-check. See [AGENTS.md](https://github.com/NourMtir0722/Paperlab/blob/main/AGENTS.md) and [docs/llms.txt](https://github.com/NourMtir0722/Paperlab/blob/main/docs/llms.txt).
 - **Accessible by default** — `prefers-reduced-motion` freezes behaviors at their pose and disables physics and entrances, a hidden DOM mirror carries the content for screen readers and find-in-page, and a flat DOM fallback renders when WebGL isn't available.
 
@@ -229,7 +229,7 @@ pnpm knip           # dead code and unused exports
 pnpm build
 ```
 
-Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All four test commands are CI gates, along with `publint` and `are-the-types-wrong` on the published package.
+Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All six test commands are CI gates, along with `publint` and `are-the-types-wrong` on the published package.
 
 ### Measurement
 

--- a/tools/dropdown-check.mjs
+++ b/tools/dropdown-check.mjs
@@ -189,6 +189,88 @@ try {
     'a resize still dismisses it',
     await closedBy(() => page.setViewportSize({ width: 1500, height: 950 })),
   )
+
+  // ── The keyboard contract ───────────────────────────────────────────────
+  // A navigation key names an option: closed, that opens the list on it, and
+  // the value does not move until Enter, Space or a click. Home and End used
+  // to commit on the spot instead, so one keystroke could swap the sculpt for
+  // another preset and rebuild the canvas with no list ever shown.
+  await dismiss()
+  const shownValue = async () => ((await presetPicker.textContent()) ?? '').replace('▾', '').trim()
+  const openBy = async (key) => {
+    await presetPicker.focus()
+    await page.keyboard.press(key)
+    return await list
+      .first()
+      .waitFor({ state: 'attached', timeout: SETTLE })
+      .then(() => true)
+      .catch(() => false)
+  }
+
+  // Start from the top of the list. The run above left the picker on the last
+  // preset, and there "End committed it" and "End did nothing" produce the
+  // same value — the check would pass on the broken behaviour too.
+  if (await openList(presetPicker)) {
+    const first = list.first().locator('.select-option').first()
+    const firstName = (await first.textContent())?.trim()
+    await first.click({ timeout: SETTLE }).catch(() => {})
+    await page
+      .waitForFunction(
+        (want) =>
+          (
+            document.querySelector('[role=combobox][aria-label="Choose a built-in preset"]')?.textContent ??
+            ''
+          ).includes(want),
+        firstName ?? '',
+        { timeout: SETTLE },
+      )
+      .catch(() => {})
+  }
+  await dismiss()
+  // Park the pointer clear of the list. Hover follows the mouse, and a cursor
+  // left sitting over an option would be answering these keyboard checks.
+  await page.mouse.move(10, 10)
+
+  const before = await shownValue()
+  const endOpened = await openBy('End')
+  check('End on a closed select opens the list', endOpened)
+  // If it did not open, End committed instead — the exact regression this
+  // section is here for. Say so for each remaining check rather than throwing
+  // on the list that is not there and losing the rest of the run.
+  const last = endOpened ? (await list.first().locator('.select-option').last().textContent())?.trim() : null
+  check(
+    'and does not commit on its own',
+    endOpened && (await shownValue()) === before,
+    endOpened ? `still "${before}"` : `was "${before}", now "${await shownValue()}"`,
+  )
+
+  let commits = false
+  if (endOpened) {
+    await page.keyboard.press('Enter')
+    commits = await page
+      .waitForFunction(
+        (want) =>
+          (
+            document.querySelector('[role=combobox][aria-label="Choose a built-in preset"]')?.textContent ??
+            ''
+          ).includes(want),
+        last ?? '',
+        { timeout: SETTLE },
+      )
+      .then(() => true)
+      .catch(() => false)
+  }
+  check('Enter is what commits it', commits, `wanted "${last}"`)
+
+  // Whatever the value is by now, backing out of the list must not move it.
+  const beforeHome = await shownValue()
+  check('Home on a closed select opens the list', await openBy('Home'))
+  await page.keyboard.press('Escape')
+  await list
+    .first()
+    .waitFor({ state: 'detached', timeout: SETTLE })
+    .catch(() => {})
+  check('Escape leaves the value alone', (await shownValue()) === beforeHome, `still "${beforeHome}"`)
 } finally {
   await browser.close()
   stop()


### PR DESCRIPTION
Closes out the keyboard inconsistency flagged in #61 — and two more defects in the same widget that turned up on the way.

## 1. The keyboard contract was split

On a **closed** select, ArrowDown opened the list, but ArrowUp, Home and End committed on the spot. So `Home` on a closed picker silently swapped the sculpt for the first preset and rebuilt the canvas, with no list ever shown and nothing asked. The comment directly above claimed all the arrows behaved the other way, so the code and its documentation disagreed about which of them was right.

One rule now: **a navigation key names an option.** Closed, that opens the list on it; open, it moves the highlight to it. Arrows, Home, End and typeahead all work that way, and nothing changes the value until Enter, Space or a click says so.

That is the [ARIA select-only combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/), which is the contract this widget opted into the moment it claimed `role="combobox"` over a `role="listbox"` — so it is the one to settle on rather than a coin toss between macOS and Windows habits.

## 2. Focus never entered the listbox

The effect that moves focus into the list ran on mount — while the list is still `visibility: hidden`, waiting for `useLayoutEffect` to measure where it goes. A hidden element cannot take focus, so `focus()` went into the void on every single open, and the listbox was unreachable to anything that follows focus.

**This one is live.** It reproduces on the deployed site, not just locally:

```
PROD (before this PR) — opened by click:
  activeElement = select-trigger open preset-select   <- never the listbox
```

It waits for the measurement now.

## 3. Hover overruled the key that opened the list

Options used `mouseenter`, which fires on an element that *appears beneath a stationary pointer* — not only when the pointer moves onto it. Opening the list under wherever the cursor already sat therefore stole the highlight from the keyboard: press End, and the highlight landed on whatever happened to be under your hand rather than on the last option.

`mousemove` instead. Hover follows the hand, and only when it moves.

## Verified

```
opened by CLICK   -> {"active":"receipt-unroll","focus":"listbox"}
End               -> {"active":"typed-note","focus":"listbox"}
Enter committed   -> typed-note
Home              -> {"active":"receipt-unroll","focus":"listbox"}
Escape kept value -> typed-note
typeahead "v"     -> {"active":"vintage-note"} | value still typed-note
console errors: none
```

Five new checks in `pnpm test:dropdown` guard the contract — that End opens rather than commits, that Enter is what commits, that Escape leaves the value alone. Reverting the contract takes the gate from **30/30 to 25/30**.

## Also

`pnpm test:route` is now in both harness tables. It was the one CI gate missing from them, and the regenerated `packages/paperlab/README.md` is committed alongside — that generated-file gate is what caught me out in #61.

## Checks

`lint`, `typecheck`, `test`, `knip`, `build`, `test:dropdown` all green, no generated drift.

No changeset — `@paperlab/editor` is private; the published `paperlab` package is untouched apart from its generated README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preset dropdown keyboard behavior for more predictable selection.
  - Arrow keys, Home, End, and typeahead now open the menu without immediately changing the selected value.
  - Enter, Space, or clicking commits a selection, while Escape closes the menu without changes.
  - Improved focus and pointer highlighting behavior when opening dropdowns.

- **Tests**
  - Added automated checks covering dropdown keyboard interactions.
  - Added a routing verification command to confirm site-root navigation directs devices to the appropriate app.

- **Documentation**
  - Documented the new routing verification check in project guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->