### PR TITLE
fix(ui): five things a picture found and no test did

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,19 @@
+---
+'paperlab': patch
+---
+
+Stop the stage agent brief promising a figure that is not there.
+
+`showFigure` defaults to false and every built-in stage preset leaves it
+there, so the common export is a camera moving through an empty hall.
+`describeStage` already knew that and withheld the "a small dark figure
+walking between them" clause — but the payload's opening sentence claimed
+"with a figure walking through it" unconditionally, and the scroll clause was
+gated on `scroll` rather than on the figure, so it promised "scrolling the
+page walks the figure deeper into it" as well. Both now follow the figure, and
+the scroll clause names the camera when there is nobody to walk.
+
+This matters because the brief's description is the acceptance test a
+receiving agent checks the render against: a figure named there is a figure it
+goes looking for, and the library ships no assets — a figure is always the
+caller's own model on the caller's own URL.

--- a/.changeset/tall-moons-shake.md
+++ b/.changeset/tall-moons-shake.md
@@ -1,0 +1,15 @@
+---
+'paperlab': patch
+---
+
+Hand the WebGL context back when a canvas unmounts.
+
+A browser allows a page about sixteen live WebGL contexts and then starts
+killing the oldest. React Three Fiber disposes the renderer's own resources on
+unmount, but the drawing context itself survives until the garbage collector
+reaches the canvas — so anything that mounts and unmounts paper as it scrolls
+exhausts the ceiling with contexts belonging to sheets that are no longer on
+screen. `<Paper>`, `<PaperField>` and `<PaperStage>` now release the context
+explicitly. Measured on the reference page: one scroll to the bottom went from
+101 "Too many active WebGL contexts" warnings to none, at an unchanged peak of
+thirteen simultaneous canvases.

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -167,6 +167,17 @@ export function App() {
       ...(field.slotStates[i] ? { states: field.slotStates[i] } : {}),
     }
   })
+  // How many slots are showing a card that is NOT theirs.
+  //
+  // The demo pool above is preview dressing, and `fieldExportInput` leaves it
+  // out on purpose — a slot's real content lives in its preset, and the
+  // editor's sample cards are not the caller's to ship. Both halves of that
+  // are right, and together they made the composer lie: the default field is
+  // fourteen `blank-sheet` slots, so what you compose against is fourteen
+  // typeset cards and what Export hands you is fourteen blank sheets, with
+  // nothing on screen saying so. Counting them is what lets the rail say it.
+  const sampledSlots = fieldPapers.filter((paper) => 'content' in paper).length
+
   const fieldZones = field.zones.map(zoneToConfig)
   const fieldScene = sceneSchema.parse(field.scene)
 
@@ -387,6 +398,15 @@ export function App() {
                 </li>
               ))}
             </ul>
+            {sampledSlots > 0 && (
+              <p className="slot-note">
+                {sampledSlots === field.slots.length ? 'Every paper is' : `${sampledSlots} papers are`}{' '}
+                showing a <strong>sample card</strong>, so an empty field reads as a drawer of records rather
+                than as blank sheets. Samples are preview only — an export carries each preset's own art
+                instead. Pick a preset that brings its own content, or edit one, and the export matches what
+                you see.
+              </p>
+            )}
           </>
         )}
       </aside>

--- a/apps/editor/src/chrome/Transport.tsx
+++ b/apps/editor/src/chrome/Transport.tsx
@@ -80,6 +80,10 @@ export function Transport({ paperRef, scrubRef, resetKey }: TransportProps) {
         ref={scrubRef}
         className="scrubber"
         type="range"
+        // The only control in the transport with no visible label — the play
+        // button carries a glyph, this carries a track. Unnamed, a screen
+        // reader announces it as a bare slider from 0 to 1.
+        aria-label="Progress through the behavior"
         min={0}
         max={1}
         step={0.001}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1023,6 +1023,25 @@ button.export:hover {
   font-weight: 600;
 }
 
+/* The composer's one caveat, under the slot list it is about. Same voice as
+   .stage-note and sat apart from the rail by a rule, because it is a note
+   about the papers rather than another control. */
+.slot-note {
+  color: var(--ink-body);
+  font-size: 12px;
+  line-height: 1.55;
+  margin: 12px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--hair);
+}
+
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint component — the
+   composer's slot note and an export-frame button never match one element. */
+.slot-note strong {
+  color: var(--ink-2);
+  font-weight: 600;
+}
+
 .stage-presets {
   list-style: none;
   margin: 0 0 16px;

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -176,10 +176,19 @@ button.primary:hover {
 }
 
 .write span {
+  /* Carries its own ground, for the reason .wordmark does: the hall behind
+     this is bright cream more often than not, and 55% white on cream measured
+     2.55:1 on a phone — the label of the one control the whole mode is about,
+     unreadable. A pill would be heavy on a field label, so this is the same
+     glass, sized to the text and sitting only under it. */
+  align-self: flex-start;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--glass-fill);
   font-size: 11px;
   letter-spacing: 0.09em;
   text-transform: uppercase;
-  color: var(--ink-body);
+  color: var(--ink-2);
 }
 
 textarea {
@@ -226,10 +235,18 @@ textarea::placeholder {
 /* The one instruction the mode needs. It is not obvious that a rendered
    scene can be grabbed, and nobody discovers an arrow key by accident. */
 .walkhint {
+  /* Same rule as .write span. This one happens to sit over the dark floor at
+     the opening camera position and reads fine there — but it is the same
+     bare-text-on-a-live-render pattern, and it fails the moment the walk
+     reaches a lit part of the hall. */
+  align-self: flex-start;
   margin: 0 0 8px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--glass-fill);
   font-size: 11px;
   letter-spacing: 0.04em;
-  color: var(--ink-body);
+  color: var(--ink-2);
 }
 
 .chip {

--- a/packages/paperlab/src/Paper.tsx
+++ b/packages/paperlab/src/Paper.tsx
@@ -4,6 +4,7 @@ import { PaperMesh, useResolvedConfig, type PaperHandle, type PaperMeshProps } f
 import { PaperFallback, PaperMirror, supportsWebGL } from './a11y'
 import { PaperLighting } from './scene/PaperLighting'
 import { PaperBackdrop } from './scene/backdrop'
+import { ReleaseContextOnUnmount } from './scene/release'
 
 export interface PaperProps extends PaperMeshProps {
   /** Extra children rendered inside the canvas (lights are provided). */
@@ -47,6 +48,7 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
           />
           <PaperMesh ref={ref} {...meshProps} />
           {children}
+          <ReleaseContextOnUnmount />
         </Canvas>
       ) : (
         <PaperFallback config={config} />

--- a/packages/paperlab/src/PaperField.tsx
+++ b/packages/paperlab/src/PaperField.tsx
@@ -5,6 +5,7 @@ import { forwardRef, useEffect, useMemo, useRef } from 'react'
 import { sceneSchema, type PaperConfigInput, type SceneConfigInput } from './config/schema'
 import { PaperLighting } from './scene/PaperLighting'
 import { PaperBackdrop } from './scene/backdrop'
+import { ReleaseContextOnUnmount } from './scene/release'
 import { usePrefersReducedMotion } from './a11y'
 import { DropZoneContext, DropZoneRegistry, type DropZoneConfig, type PlacedPaper } from './field/dropZones'
 import {
@@ -332,6 +333,7 @@ export const PaperField = forwardRef<THREE.Group, PaperFieldProps>(function Pape
           <PaperLighting preset={rig.lighting} light={rig.light} floor={-2.4} scale={14} />
           <PaperFieldMesh ref={ref} a11yControllerRef={a11yRef} {...meshProps} />
           {children}
+          <ReleaseContextOnUnmount />
         </Canvas>
         {interactive && <FieldKeyboardMirror papers={papers} controller={a11yRef} />}
       </DropZoneContext.Provider>

--- a/packages/paperlab/src/scene/release.tsx
+++ b/packages/paperlab/src/scene/release.tsx
@@ -1,0 +1,39 @@
+import { useThree } from '@react-three/fiber'
+import { useEffect } from 'react'
+
+/**
+ * Hands the WebGL context back when the canvas unmounts.
+ *
+ * A browser gives a page about sixteen live WebGL contexts and then starts
+ * killing the oldest to make room. Anything that mounts and unmounts paper as
+ * it scrolls — the reference page is forty-odd cards doing exactly that — goes
+ * over that ceiling not because too many sheets are on screen at once, but
+ * because the ones that left never gave their context back.
+ *
+ * React Three Fiber disposes the renderer's own resources on unmount, and that
+ * is not the same thing: the drawing context itself survives until the garbage
+ * collector gets to the canvas, which is whenever it likes. `forceContextLoss`
+ * is three.js's way of saying *now*, and it is the documented one.
+ *
+ * Measured on the reference page before this existed: one scroll to the bottom
+ * produced 101 "Too many active WebGL contexts" warnings at a peak of thirteen
+ * simultaneous canvases — comfortably under the cap, and still exhausting it.
+ * Nothing was visibly blank, because a card that scrolls back into view
+ * remounts and builds a fresh context; the cost was paid in that churn.
+ *
+ * Rendered inside a `<Canvas>`, where `useThree` can reach the renderer.
+ */
+export function ReleaseContextOnUnmount() {
+  const gl = useThree((s) => s.gl)
+  useEffect(
+    () => () => {
+      // Both, in this order. `forceContextLoss` releases the context and
+      // `dispose` releases what the renderer still holds against it; calling
+      // dispose alone is what leaves the context standing.
+      gl.forceContextLoss()
+      gl.dispose()
+    },
+    [gl],
+  )
+  return null
+}

--- a/packages/paperlab/src/stage/PaperStage.tsx
+++ b/packages/paperlab/src/stage/PaperStage.tsx
@@ -11,6 +11,7 @@ import { getLayout } from '../field/layouts'
 import { PaperLighting } from '../scene/PaperLighting'
 import { resolveLighting } from '../scene/lighting'
 import { LightRig } from '../scene/rig'
+import { ReleaseContextOnUnmount } from '../scene/release'
 import { getWalkPath } from './path'
 import { stageCamera, walkPoint } from './camera'
 import { Figure } from './Figure'
@@ -671,6 +672,7 @@ export function PaperStage({ children, className, style, ...sceneProps }: PaperS
       >
         <PaperStageScene {...sceneProps} />
         {children}
+        <ReleaseContextOnUnmount />
       </Canvas>
     </div>
   )

--- a/packages/paperlab/src/stage/export.test.ts
+++ b/packages/paperlab/src/stage/export.test.ts
@@ -123,7 +123,18 @@ describe('describeStage', () => {
   it('names the walk shape, and says when scroll drives it', () => {
     expect(describeStage(base({ stage: { path: walks.ess } }))).toContain('"ess" walk')
     expect(describeStage(base({ stage: { path: walks.ring } }))).toContain('closed loop')
-    expect(describeStage(base({ scroll: true }))).toContain('scrolling the page walks the figure')
+    expect(describeStage(base({ scroll: true }))).toContain('scrolling the page')
+  })
+
+  it('says what scroll actually moves, which is the figure only if there is one', () => {
+    // `showFigure` is off by default and every built-in preset leaves it
+    // there, so the common scroll export moves a camera through an empty
+    // hall. Naming a figure there sends the reader hunting for one.
+    expect(describeStage(base({ scroll: true }))).toContain('carries the camera deeper')
+    expect(describeStage(base({ scroll: true }))).not.toContain('walks the figure')
+    expect(describeStage(base({ scroll: true, stage: { showFigure: true } }))).toContain(
+      'walks the figure deeper',
+    )
   })
 
   it('mentions the figure only when one is actually drawn', () => {
@@ -146,6 +157,17 @@ describe('stage agent payload', () => {
     expect(payload).toContain('You should see')
     // The mistake a receiving agent would otherwise make.
     expect(payload).toContain("don't add OrbitControls")
+  })
+
+  it('does not open by promising a figure the stage has not got', () => {
+    // The first line is the one sentence a receiving agent reads before it
+    // reads any code, so a figure claimed there is a figure it goes looking
+    // for. The library ships no assets — a figure is always the caller's own
+    // model on the caller's own URL.
+    expect(buildStageAgentPayload(base())).not.toContain('with a figure walking through it')
+    expect(buildStageAgentPayload(base({ stage: { showFigure: true } }))).toContain(
+      'with a figure walking through it',
+    )
   })
 
   it('tells the receiver the scroll variant brings its own height', () => {

--- a/packages/paperlab/src/stage/export.ts
+++ b/packages/paperlab/src/stage/export.ts
@@ -147,7 +147,18 @@ export function describeStage(input: StageExportInput): string {
     .filter(([, value]) => value !== undefined)
     .map(([key]) => key)
   if (moved.length > 0) parts.push(`with its ${moved.join(', ')} set by hand`)
-  if (input.scroll) parts.push('and scrolling the page walks the figure deeper into it')
+  // Gated on the figure, not just on `scroll`. `showFigure` defaults to
+  // false and every built-in stage preset leaves it there, so the common
+  // export has nobody walking — and this clause was promising one anyway, in
+  // the same sentence the reader is told to check the render against. What
+  // scroll moves when the stage is empty is the camera.
+  if (input.scroll) {
+    parts.push(
+      stage.showFigure
+        ? 'and scrolling the page walks the figure deeper into it'
+        : 'and scrolling the page carries the camera deeper into it',
+    )
+  }
   return parts.join(', ')
 }
 
@@ -279,7 +290,16 @@ export function buildStageAgentPayload(input: StageExportInput): string {
     : `4. Sizing: the component fills its parent container. Place it where I ask;
    give the parent an explicit height.`
 
-  return `Integrate a Paperlab stage — paper as architecture, with a figure walking through it — into this project. (paperlab agent-payload v${AGENT_PAYLOAD_VERSION})
+  // Same reason the scroll clause is gated: a stage with `showFigure` off —
+  // which is the default, and every built-in preset — has no figure in it,
+  // and opening the brief by promising one sends the reader looking for a
+  // thing the component cannot render. The library ships no assets, so a
+  // figure is always the caller's own model on the caller's own URL.
+  const subject = stageSchema.parse(input.stage).showFigure
+    ? 'paper as architecture, with a figure walking through it'
+    : 'paper as architecture, banners hung along a walk you move through'
+
+  return `Integrate a Paperlab stage — ${subject} — into this project. (paperlab agent-payload v${AGENT_PAYLOAD_VERSION})
 
 1. Install the dependencies:
 


### PR DESCRIPTION
An audit of the three apps for UI breakdowns. Everything the repo already
gates on passed first — typecheck, lint, 798 unit tests, knip, route, share,
dropdown, stage-drive and GPU parity — so every finding here is something only
rendering the thing and looking at it, or measuring it, could surface.

## The Field composer lied about what it exports

The composer fills each empty slot with a sample card so the mode does not
open on fourteen blank sheets, and `fieldExportInput` leaves those samples out
on purpose, because a slot's real content lives in its preset and the editor's
cards are not the caller's to ship. Both halves are right; together they made
the tool dishonest. The default field is fourteen `blank-sheet` slots, so you
compose against fourteen typeset cards and Export hands you fourteen blank
ones — with nothing on screen saying so.

The rail now counts the sampled slots and says which. The count falls as slots
gain content of their own ("Every paper is" → "13 papers are"), so it tracks
the real divergence rather than being a static disclaimer.

## "Write the room" was unreadable on a phone

**2.55:1** measured at 390px against a 4.5:1 floor — the label of the one
control the playground is about, on the mobile front door. The stylesheet
already states the rule ("everything floating over the scene carries its own
ground"); this label and the walk hint were the only two floating elements
without a plate, and a backlit hall is bright behind both. **8.11:1** now.
Both also shrink to their text rather than blocking a full-width strip of a
scene you are meant to be able to drag.

## WebGL contexts were never handed back

R3F disposes the renderer's resources on unmount; the drawing context itself
survives until GC. One scroll of the reference page raised **101** "Too many
active WebGL contexts" warnings at a peak of thirteen simultaneous canvases —
under the cap, and still exhausting it. Nothing was visibly blank, because a
card scrolling back into view rebuilds a context; the cost was paid in churn.
**Zero** warnings now. `<Paper>`, `<PaperField>` and `<PaperStage>` release the
context explicitly, so this fixes it for any consumer that mounts and unmounts
paper as it scrolls.

## The stage brief promised a figure that was never there

`showFigure` defaults to false and `presets.test.ts` asserts every built-in
preset leaves it there, so the ordinary Stage export is a camera moving through
an empty hall. `describeStage` already knew that and withheld its figure
clause — but the payload's opening sentence claimed "with a figure walking
through it" unconditionally, and the scroll clause was gated on `scroll`
rather than on the figure. So the default Stage export twice promised a
walking person, in a document whose "You should see …" line is the acceptance
test a receiving agent checks the render against. An agent verifying
faithfully would hunt for a figure the component cannot draw: the library ships
no assets, so a figure is always the caller's own model on their own URL.

The existing test asserting the old scroll wording was encoding the bug —
`base()` has no figure — so it now checks what scroll actually moves, in both
branches.

## Also

The editor's timeline scrubber announced itself to a screen reader as a bare
slider from 0 to 1.

## Verification

- Build, **800** tests (+2 new), lint, knip, typecheck all clean.
- Every harness re-run green: parity 37/37, dropdown 30/30, stage-drive, share
  10/10, route 10/10.
- The context change touches all three canvas owners, so mode switching (which
  remounts the canvas via `key={mode}`) was re-driven specifically — clean.
- All **26** export paths driven across the three modes: every code, picture
  and clip export produced correct output, every generated component compiled
  against the real library, and the exported stage component rendered the same
  scene the editor showed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stage descriptions and integration briefs to accurately reflect whether a figure is present and whether scrolling moves the figure or camera.
  * Improved WebGL canvas cleanup when Paper components are removed, helping prevent accumulated browser rendering contexts.

* **Editor Improvements**
  * Added a note clarifying that field-mode sample content is preview-only.
  * Improved accessibility for the behavior progress scrubber.

* **Visual Updates**
  * Refined playground hint labels with clearer contrast, spacing, and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->