### PR TITLE
fix(paperlab): the generated scroll component also named a missing figure

### DIFF
--- a/.changeset/lucky-buses-share.md
+++ b/.changeset/lucky-buses-share.md
@@ -1,0 +1,12 @@
+---
+'paperlab': patch
+---
+
+Stop the generated scroll component shipping a comment about a figure that is
+not in the scene.
+
+The stage brief's figure claims were gated on `showFigure`, but the comment
+baked into the generated component source was not — so a scroll export planted
+`// Scroll the section, walk the figure.` in the receiver's own file whether or
+not one was drawn. `showFigure` is off by default and every built-in stage
+preset leaves it there. It now names the camera when nobody is walking.

--- a/packages/paperlab/src/stage/export.test.ts
+++ b/packages/paperlab/src/stage/export.test.ts
@@ -159,6 +159,15 @@ describe('stage agent payload', () => {
     expect(payload).toContain("don't add OrbitControls")
   })
 
+  it('does not ship a comment naming a figure that is not in the scene', () => {
+    // This one lands as a code comment in the receiver's own file, so it
+    // outlives the brief that carried it.
+    expect(buildStageComponentSource(base({ scroll: true }))).toContain('Scroll the section, move the camera')
+    expect(buildStageComponentSource(base({ scroll: true, stage: { showFigure: true } }))).toContain(
+      'Scroll the section, walk the figure',
+    )
+  })
+
   it('does not open by promising a figure the stage has not got', () => {
     // The first line is the one sentence a receiving agent reads before it
     // reads any code, so a figure claimed there is a figure it goes looking

--- a/packages/paperlab/src/stage/export.ts
+++ b/packages/paperlab/src/stage/export.ts
@@ -216,6 +216,11 @@ export function buildStageComponentSource(input: StageExportInput): string {
     ? `\n\nconst banner = ${stringifyStage(diffConfig(paperConfigSchema.parse(input.paper)))} satisfies PaperConfigInput`
     : ''
   const textConst = input.text?.trim() ? `\n\nconst text = ${JSON.stringify(input.text)}` : ''
+  // What the scroll actually drives, for the comment that ships inside the
+  // generated component. `showFigure` is off by default, so this line was
+  // telling the receiver — in their own codebase, in their own file — to
+  // watch a figure that is not in the scene.
+  const scrolls = stageSchema.parse(input.stage).showFigure ? 'walk the figure' : 'move the camera'
   const images = input.images?.length ? exportableImages(input.images) : null
   const imagesConst = images
     ? `\n${
@@ -248,7 +253,7 @@ export function ${name}() {
   const ref = useRef<HTMLDivElement>(null)
   const [progress, setProgress] = useState(0)
 
-  // Scroll the section, walk the figure. The stage is pinned for the height
+  // Scroll the section, ${scrolls}. The stage is pinned for the height
   // of the section, so the page scrolling past it IS the walk.
   useEffect(() => {
     const el = ref.current


### PR DESCRIPTION
A third instance of the figure claim fixed in #64 — and the one that travels
furthest.

`describeStage` and the agent brief's opening line were both gated on
`showFigure`. The comment baked into `buildStageComponentSource` was not, so a
scroll export shipped

```tsx
// Scroll the section, walk the figure. The stage is pinned for the height
// of the section, so the page scrolling past it IS the walk.
```

into the receiver's own file regardless. `showFigure` is off by default and
`presets.test.ts` asserts every built-in stage preset leaves it there, so the
ordinary export planted a comment describing a figure that is not in the
scene. Unlike the brief — read once, then thrown away — this one stays in
their codebase and outlives the paste.

Now says "move the camera" when nobody is walking, with a test on both
branches.

**Credit where it is due:** CodeRabbit flagged this on #64. It was right that
the sweep there was incomplete — I fixed the description and the brief's
opening line and missed the generated source.

620 library tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated scroll instructions to reference moving the camera when no figure is present.
  * Retained figure-walking instructions only for scenes that include a figure.

* **Tests**
  * Added coverage verifying the generated instructions for both scene variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->