### PR TITLE
fix(editor): remove the stage and field rail hint notes

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -167,16 +167,6 @@ export function App() {
       ...(field.slotStates[i] ? { states: field.slotStates[i] } : {}),
     }
   })
-  // How many slots are showing a card that is NOT theirs.
-  //
-  // The demo pool above is preview dressing, and `fieldExportInput` leaves it
-  // out on purpose — a slot's real content lives in its preset, and the
-  // editor's sample cards are not the caller's to ship. Both halves of that
-  // are right, and together they made the composer lie: the default field is
-  // fourteen `blank-sheet` slots, so what you compose against is fourteen
-  // typeset cards and what Export hands you is fourteen blank sheets, with
-  // nothing on screen saying so. Counting them is what lets the rail say it.
-  const sampledSlots = fieldPapers.filter((paper) => 'content' in paper).length
 
   const fieldZones = field.zones.map(zoneToConfig)
   const fieldScene = sceneSchema.parse(field.scene)
@@ -358,10 +348,6 @@ export function App() {
                 )
               })}
             </ul>
-            <p className="stage-note">
-              Under <strong>Content</strong>, type words and the space is rebuilt out of them — one column per
-              banner, stacked down the drop — or hang your own pictures, one per drop.
-            </p>
           </>
         ) : (
           <>
@@ -398,15 +384,6 @@ export function App() {
                 </li>
               ))}
             </ul>
-            {sampledSlots > 0 && (
-              <p className="slot-note">
-                {sampledSlots === field.slots.length ? 'Every paper is' : `${sampledSlots} papers are`}{' '}
-                showing a <strong>sample card</strong>, so an empty field reads as a drawer of records rather
-                than as blank sheets. Samples are preview only — an export carries each preset's own art
-                instead. Pick a preset that brings its own content, or edit one, and the export matches what
-                you see.
-              </p>
-            )}
           </>
         )}
       </aside>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1009,39 +1009,6 @@ button.export:hover {
   border-color: var(--ink-body);
 }
 
-.stage-note {
-  color: var(--ink-body);
-  font-size: 12px;
-  line-height: 1.55;
-  margin: 0 0 10px;
-}
-
-/* biome-ignore lint/style/noDescendingSpecificity: disjoint component — never
-   matches the same element as the .export-dropdown rule above. */
-.stage-note strong {
-  color: var(--ink-2);
-  font-weight: 600;
-}
-
-/* The composer's one caveat, under the slot list it is about. Same voice as
-   .stage-note and sat apart from the rail by a rule, because it is a note
-   about the papers rather than another control. */
-.slot-note {
-  color: var(--ink-body);
-  font-size: 12px;
-  line-height: 1.55;
-  margin: 12px 0 0;
-  padding-top: 12px;
-  border-top: 1px solid var(--hair);
-}
-
-/* biome-ignore lint/style/noDescendingSpecificity: disjoint component — the
-   composer's slot note and an export-frame button never match one element. */
-.slot-note strong {
-  color: var(--ink-2);
-  font-weight: 600;
-}
-
 .stage-presets {
   list-style: none;
   margin: 0 0 16px;


### PR DESCRIPTION
Removes the two explanatory paragraphs in the editor's left rail.

- **Stage rail** — the `.stage-note` paragraph ("Under **Content**, type words and the space is rebuilt out of them…").
- **Field rail** — the `.slot-note` caveat ("N papers are showing a **sample card**…"), plus the `sampledSlots` counter and its comment, which existed only to feed that note.
- **styles.css** — the `.stage-note` / `.slot-note` rules and their `strong` variants, which now match nothing.

`tsc --noEmit`, biome, and the editor's 113 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)