### PR TITLE
fix(stage): the source glow speckled green in Safari

### DIFF
--- a/.changeset/green-speckle-source-glow.md
+++ b/.changeset/green-speckle-source-glow.md
@@ -1,0 +1,11 @@
+---
+'paperlab': patch
+---
+
+Stage mode's source no longer speckles green in Safari. The glow plane faded
+through its alpha channel, and a 2D canvas stores premultiplied pixels — so
+uploading it un-premultiplied made the browser divide the colour back out,
+which along the near-transparent tail amplified 8-bit rounding into off-hue
+texels. WebKit's rounding made those visible as a drift of green dots across
+the far wall. The falloff is now premultiplied into the colour on an opaque
+texture and added to the room, which is also the more honest model of a light.

--- a/packages/paperlab/src/stage/Surround.tsx
+++ b/packages/paperlab/src/stage/Surround.tsx
@@ -71,16 +71,31 @@ export function makeGlowTexture(color: string): THREE.CanvasTexture {
   const ctx = canvas.getContext('2d')!
   const glow = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2)
   const c = new THREE.Color(color)
-  const rgb = `${(c.r * 255) | 0}, ${(c.g * 255) | 0}, ${(c.b * 255) | 0}`
-  // Same colour throughout — only the alpha falls, so the fade never tints.
+  // The falloff is carried by the COLOUR, on a texture that stays fully
+  // opaque, and `Source` adds it to the room rather than mixing into it.
+  //
+  // It was an alpha ramp over a flat colour, which is the same picture in
+  // theory and a drift of green dots across the far wall in Safari. A 2D
+  // canvas stores its pixels premultiplied; uploading one as an
+  // un-premultiplied texture makes the browser divide the colour back out,
+  // and along this tail — where alpha reaches 3/255 — that division
+  // multiplies an 8-bit rounding error by eighty. WebKit's rounding puts a
+  // few of those texels off-hue, and this plane is the widest thing in
+  // frame, so a handful of bad texels became speckle over the whole end of
+  // the hall. Premultiplying the ramp here means there is nothing to divide
+  // back out: what is drawn is what is uploaded.
+  //
+  // Adding is the more honest model anyway — a source puts light INTO the
+  // room, it does not stand in front of it — and it is what stops the tail
+  // from very slightly darkening everything it crosses.
   //
   // A held core and then a long tail. The core has to stay — it is the one
   // thing in frame brighter than the paper, and a falloff that starts at the
-  // centre gives a soft warm haze with nothing to walk toward. What changed
-  // is the tail: dropping from full to nothing over the last 45% put a
-  // visible RIM on the plane, a disc of light with an edge hanging in the
-  // room like a moon, and light does not have an edge.
-  for (const [stop, alpha] of [
+  // centre gives a soft warm haze with nothing to walk toward. The tail is
+  // long for its own reason: dropping from full to nothing over the last 45%
+  // put a visible RIM on the plane, a disc of light with an edge hanging in
+  // the room like a moon, and light does not have an edge.
+  for (const [stop, level] of [
     [0, 1],
     [0.5, 1],
     [0.62, 0.66],
@@ -89,7 +104,8 @@ export function makeGlowTexture(color: string): THREE.CanvasTexture {
     [0.94, 0.03],
     [1, 0],
   ] as const) {
-    glow.addColorStop(stop, `rgba(${rgb}, ${alpha})`)
+    const scaled = `${(c.r * 255 * level) | 0}, ${(c.g * 255 * level) | 0}, ${(c.b * 255 * level) | 0}`
+    glow.addColorStop(stop, `rgb(${scaled})`)
   }
   ctx.fillStyle = glow
   ctx.fillRect(0, 0, size, size)
@@ -147,6 +163,10 @@ export function Source({
       <meshBasicMaterial
         map={texture}
         transparent
+        // The map is premultiplied and opaque — see `makeGlowTexture` — so
+        // the falloff has to be applied by ADDING it, and adding is what a
+        // light does to a room in any case.
+        blending={THREE.AdditiveBlending}
         // `color` multiplies the map, and a THREE.Color is not clamped to 1,
         // so this is how a basic material carries HDR.
         color={new THREE.Color(intensity, intensity, intensity)}

--- a/packages/paperlab/src/stage/surround.test.ts
+++ b/packages/paperlab/src/stage/surround.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makeGlowTexture } from './Surround'
+
+/**
+ * A stand-in for the 2D context, recording only what the glow is built from.
+ * The library runs its tests in node, and the one thing worth asserting here
+ * is what gets written into the gradient — no pixels have to exist for that.
+ */
+function recordingCanvas() {
+  const stops: [number, string][] = []
+  const ctx = {
+    fillStyle: '' as unknown,
+    createRadialGradient: () => ({
+      addColorStop: (offset: number, color: string) => {
+        stops.push([offset, color])
+      },
+    }),
+    fillRect: () => {},
+  }
+  vi.stubGlobal('document', {
+    createElement: () => ({ width: 0, height: 0, getContext: () => ctx }),
+  })
+  return stops
+}
+
+describe('makeGlowTexture', () => {
+  /**
+   * The regression this file exists for.
+   *
+   * A fade written into the alpha channel is the obvious way to build this
+   * and it is the one that breaks: a 2D canvas holds premultiplied pixels,
+   * so an un-premultiplied upload divides the colour back out, and where
+   * alpha is near zero that division turns 8-bit rounding into visible
+   * off-hue texels — green speckle across the far wall, in WebKit only.
+   * Premultiplying it here is the fix, and "every stop is opaque" is the
+   * shape of the fix that a test can hold on to.
+   */
+  it('fades by colour, never by alpha', () => {
+    const stops = recordingCanvas()
+    makeGlowTexture('#fff4e2')
+    expect(stops.length).toBeGreaterThan(2)
+    for (const [, color] of stops) expect(color).toMatch(/^rgb\(\d+, \d+, \d+\)$/)
+  })
+
+  it('still falls from the source colour to nothing', () => {
+    const stops = recordingCanvas()
+    makeGlowTexture('#ffffff')
+    const levels = stops.map(([, color]) => Number(color.match(/\d+/)?.[0]))
+    expect(levels.at(0)).toBe(255)
+    expect(levels.at(-1)).toBe(0)
+    // Monotonic, or the "long tail" the comment describes is not a tail.
+    expect(levels).toEqual([...levels].sort((a, b) => (b ?? 0) - (a ?? 0)))
+  })
+})


### PR DESCRIPTION
## What you saw

Green dots drifting across the far wall in stage mode. Safari only — Chromium (including on the same Apple GPU) renders it clean, which is why no shot in this repo ever caught it.

## Cause

`Source` is a plane with a radial falloff, and the falloff lived in the glow texture's **alpha channel** over a flat colour. A 2D canvas stores its pixels premultiplied, so uploading that canvas as an un-premultiplied texture makes the browser divide the colour back out. Along the tail — where alpha reaches `3/255` — that division multiplies an 8-bit rounding error by eighty. WebKit's rounding lands a few of those texels off-hue, and this plane is the widest thing in frame, so a handful of bad texels became speckle over the whole end of the hall.

## Fix

The ramp is premultiplied into the **colour** on a fully opaque texture, and the material adds it to what is behind instead of mixing into it. Nothing has to be divided back out. Additive is also the more honest model — a source puts light *into* a room rather than standing in front of it — and the tail no longer very slightly darkens what it crosses.

## Verification

- Reproduced in Playwright WebKit against the live demo, then bisected the scene: disabling `<Source>` was what made it vanish.
- After the fix, the off-hue pixel count goes from thousands to **zero** across all six stage presets (`nave`, `procession`, `cloister`, `threshold`, `ribbon`, `archive`) at several points along each walk.
- Chromium renders are unchanged apart from a marginally softer, marginally brighter tail.
- `surround.test.ts` holds the shape of the fix: every gradient stop must be opaque, and the ramp must still fall monotonically to nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed green speckling in Safari when viewing Stage mode.
  * Improved glow rendering for smoother, more consistent falloff across supported browsers.

* **Tests**
  * Added coverage to verify glow gradients fade through opaque colors as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->