### PR TITLE
feat(paper): the sheet keeps what you fold into it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,30 @@ overrides ride on the slot: `papers: [{ preset, states: { states: { hover:
 | `ribbon` | pool, curl, drape | a strip hung the full drop of a room, pooling where it lands. The one behavior that reads its sheet: the pool begins a fraction above the BOTTOM edge, not at the centre |
 | `settle` | relax, lift, corner, slack | a sheet that has landed and relaxed. The pose AFTER `fall`, and everything in it is static — a settled sheet that ripples is one nobody believes |
 
+### Memory — the paper keeps what you do to it
+
+Paper is plastic where cloth is elastic: fold it and the fold stays. Every deformer is a pure function of its options, so without this a sheet folded to 180° and back to 0° comes out pristine — right for cloth, wrong for paper.
+
+```tsx
+<Paper
+  preset="letter-fold"
+  memory={{
+    set: 0.6,                                          // how much of a fold this paper keeps, 0..1
+    creases: [{ angle: 270, offset: 0.23, depth: 13 }] // and the creases it already has
+  }}
+/>
+```
+
+`set` is an override on the stock's own `takesSet` — kraft 0.85 holds a crease hard, vellum 0.25 springs back. Leave it out and the stock decides. `memory: { set: 0 }` is the opt-out, and it is exactly how every sheet behaved before this existed.
+
+A **crease** names its line the way `fold` does: `angle` is the direction the fold travels, the crease line runs perpendicular to it, `offset` is the signed distance of that line from the sheet's centre. `depth` is the signed residual fold angle — the whole of what a crease is, read by both the geometry and the shading. Four maximum, which is what the crease shader carries.
+
+Creases are **recorded by folding the paper**: a fold that closes past `CREASE_MIN_GROWTH` (45°) at a line that stays put leaves one, at `peak × set × MAX_SET`. A fold whose line *travels* leaves nothing — `unroll`'s landing hinge sits at 90° forever while it walks down the sheet, and paper coming off a roll is bent at the floor, not creased. `onCrease` fires when the set changes so a host can persist it; the sheet applies its own creases immediately either way.
+
+Applied, a crease is a **floor on the fold at its line, never an addition**. While the behavior folds that line further the crease is invisible; as it lets go the angle falls to the crease's depth and stops. That is what makes a crease appear on the way *out* of a fold with nothing detecting the release.
+
+Hero path only — a crease is per-sheet state and the field is one instanced draw call.
+
 ### Physics
 
 - Idle presets (`physics: 'float' | 'tumble' | 'dangle' | 'taped' | 'breeze'`): cheap curated motion, composes WITH a behavior.
@@ -560,6 +584,7 @@ Label **drag-to-scrub** is the interaction worth preserving: full range in ~300p
 Architecture invariants (violating these is a bug, not a style choice):
 
 - **The zod schema (`config/schema.ts`) is the single source of truth.** If a feature can't serialize into a preset, it waits.
+- **Paper memory lives ABOVE the deformer stack, never inside it.** `deformers/memory.ts` watches the stack a behavior built and rewrites it before it runs; no deformer knows memory exists. Deformer purity is what the GLSL twins are identical *to* — put state in a `displace` and `test:parity` has nothing left to check.
 - **Deformers are pure vertex functions with dual JS + GLSL implementations.** Any change to one side must change the other; `pnpm test:parity` enforces it. JS runs the hero path (CPU, ≤10 papers, interactive); GLSL runs the field path (instanced).
 - **GSAP owns animated values; `useFrame` owns uniform uploads and geometry writes.** Never both on one property.
 - **Behaviors are 3–5 human-named params** ('tightness', not 'cylinderRadius') expanding to deformer stacks.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ Underneath them are seven **deformers** — `roll`, `curl`, `bend`, `fold`, `wav
 
 One sheet of words, seven papers. Stock is not a colour swap: thermal takes on banding, newsprint takes grain, vellum goes translucent and lets the light through it. On top of stock sit composable surface effects — grain, torn deckle edges, crease lines, perforation, aging — as shader chunks. Alpha-affecting effects use `alphaTest` rather than blending, so shadows stay correct.
 
+### Memory — the paper keeps what you do to it
+
+Paper is plastic where cloth is elastic. Every deformer here is a pure function of its options, so a sheet folded to 180° and back to 0° used to come out pristine — right for cloth, wrong for the one material this library models. Now it creases.
+
+A fold that closes past 45° at a line that stays put leaves a crease behind at `peak × set`, where `set` is how much that paper keeps: kraft holds one hard, vellum springs back. A fold whose line *travels* leaves nothing, which is why paper coming off a roll is bent at the floor rather than creased along it. Creases bend the sheet as well as marking it, they can be handed to a paper that was never folded (a letter that arrives having been folded once), and they serialize — into a preset, and down a share link.
+
+```tsx
+<Paper preset="letter-fold" memory={{ set: 0.6 }} onCrease={save} />
+```
+
 ### Layouts — 12
 
 ![All twelve field layouts rendered side by side](docs/media/layouts.jpg)

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -7,6 +7,7 @@ import { Behaviors } from './sections/Behaviors'
 import { Deformers } from './sections/Deformers'
 import { Physics } from './sections/Physics'
 import { Surfaces } from './sections/Surfaces'
+import { Memory } from './sections/Memory'
 import { Stocks } from './sections/Stocks'
 import { Layouts } from './sections/Layouts'
 import { Stages } from './sections/Stages'
@@ -18,6 +19,7 @@ const SECTIONS = [
   ['deformers', 'Deformers'],
   ['physics', 'Physics'],
   ['surfaces', 'Surface'],
+  ['memory', 'Memory'],
   ['stocks', 'Stocks'],
   ['layouts', 'Layouts'],
   ['stages', 'Stages'],
@@ -57,6 +59,7 @@ export function App() {
         <Deformers />
         <Physics />
         <Surfaces />
+        <Memory />
         <Stocks />
         <Layouts />
         <Stages />

--- a/apps/docs/src/sections/Memory.tsx
+++ b/apps/docs/src/sections/Memory.tsx
@@ -1,0 +1,107 @@
+import { Paper, getStock, stockNames } from 'paperlab'
+import { Live } from '../Live'
+import { Snippet } from '../Snippet'
+
+/**
+ * Memory is the one page here that documents an absence being fixed.
+ *
+ * Every other section shows a thing the library can draw. This one shows a
+ * thing it used to forget: a deformer is a pure function of its options, so
+ * the same sheet folded and unfolded came back pristine. The demonstration
+ * has to be the pair — the fold, and what is left of it — because either one
+ * alone is just a bent rectangle.
+ */
+
+/** The two lines `letter-fold` bends, as creases of increasing depth. */
+const tri = (depth: number) => [
+  { angle: 270, offset: 1.4 / 6, depth },
+  { angle: 90, offset: 1.4 / 6, depth: depth * 0.85 },
+]
+
+const LETTER = { type: 'text', text: 'folded once,\nand it shows', size: 40 } as const
+
+export function Memory() {
+  return (
+    <section id="memory">
+      <h2>Memory</h2>
+      <p className="lede">
+        Paper is plastic where cloth is elastic. Fold it and the fold stays — so a sheet carries the creases
+        it has been folded along, whether or not it is folded now. Creases are recorded by folding the paper
+        and they are ordinary config: they save into a preset and travel down a share link.
+      </p>
+
+      <div className="grid">
+        <article className="card">
+          <Live idle="flat">
+            <Paper stock="printer" content={LETTER} memory={{ creases: [] }} physics="float" />
+          </Live>
+          <h3>never folded</h3>
+          <p className="describe">
+            A sheet with nothing behind it. This is what every paper in the library looked like after being
+            folded flat and opened again, which is the thing this section exists to stop being true.
+          </p>
+        </article>
+
+        <article className="card">
+          <Live idle="creased">
+            <Paper stock="printer" content={LETTER} memory={{ creases: tri(13) }} physics="float" />
+          </Live>
+          <h3>folded once</h3>
+          <p className="describe">
+            Two creases, thirteen degrees. A crease bends the sheet as well as marking it — the flaps sit open
+            at the angle the fibres gave up at.
+          </p>
+        </article>
+
+        <article className="card">
+          <Live idle="well creased">
+            <Paper stock="kraft" content={LETTER} memory={{ creases: tri(28) }} physics="float" />
+          </Live>
+          <h3>folded hard, in kraft</h3>
+          <p className="describe">
+            Same two lines on stock that holds a crease. Kraft's <code>takesSet</code> is{' '}
+            {getStock('kraft').takesSet} against vellum's {getStock('vellum').takesSet}: thick and fibrous
+            paper takes a set and keeps it, coated and translucent paper springs most of the way back.
+          </p>
+        </article>
+
+        <article className="card">
+          <Live idle="folding">
+            <Paper preset="letter-fold" physics="none" autoplay />
+          </Live>
+          <h3>making one</h3>
+          <p className="describe">
+            Let it fold and open. A fold that closes past 45° at a line that stays put leaves a crease; one
+            whose line <em>travels</em> leaves nothing, which is why paper coming off a roll is bent at the
+            floor rather than creased along it.
+          </p>
+        </article>
+      </div>
+
+      <p className="describe">
+        <code>set</code> overrides the stock's own <code>takesSet</code>, so leaving it out lets the paper
+        decide. <code>memory={'{{ set: 0 }}'}</code> is the opt-out — perfectly elastic paper, which is how
+        every sheet behaved before this existed. Stocks, most to least retentive:{' '}
+        {[...stockNames]
+          .sort((a, b) => getStock(b).takesSet - getStock(a).takesSet)
+          .map((name) => `${name} ${getStock(name).takesSet}`)
+          .join(' · ')}
+        .
+      </p>
+
+      <Snippet
+        code={`<Paper
+  preset="letter-fold"
+  memory={{
+    set: 0.6,                    // how much of a fold this paper keeps (default: the stock's)
+    creases: [                   // and the creases it already has, up to four
+      { angle: 270, offset: 0.23, depth: 13 },
+      { angle: 90, offset: 0.23, depth: 11 },
+    ],
+  }}
+  onCrease={(creases) => save(creases)}   // fires when folding leaves a new one
+/>`}
+      />
+    </section>
+  )
+}

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -460,6 +460,20 @@ export function App() {
                 coachMarkUsed()
                 patchConfig({ behavior: patch as never }, { external: true })
               }}
+              onCrease={(creases) => {
+                // A crease is a property of the PAPER, never of one interaction
+                // state: recorded while a state is being edited it would land in
+                // that state's override diff, and the letter would arrive
+                // creased only on hover. The sheet keeps showing them either
+                // way — this is persistence, and the base config is the only
+                // place they can honestly persist to.
+                if (useEditor.getState().editingState) return
+                // Not `external`: this fires repeatedly as the fold closes, and
+                // an inspector remount per frame of a fold would collapse the
+                // folder someone is reading. The panel derives its rows from
+                // the config on every render, so it follows along anyway.
+                patchConfig({ memory: { creases } as never })
+              }}
             />
           ) : (
             <PaperFieldMesh

--- a/apps/editor/src/panels/Inspector.tsx
+++ b/apps/editor/src/panels/Inspector.tsx
@@ -38,6 +38,7 @@ import { useEditor } from '../state/store'
 import { formatItems, parseItems } from './receiptItems'
 import { pickImageAsDataUrl } from '../chrome/pickImage'
 import { lightControls } from './lightControls'
+import { memoryControls } from './memoryControls'
 import { backdropControls } from './backdropControls'
 
 /**
@@ -108,6 +109,14 @@ export function Inspector() {
     ),
     folder('Content', contentControls(config.content, patchConfig), { collapsed: true }),
     folder('Surface', surfaceControls(config.surface, config.stock, setSurface), { collapsed: true }),
+    // Between Surface and Physics on purpose: a crease is half a mark on the
+    // paper and half a bend in it, so it belongs between the panel that draws
+    // the paper and the panel that moves it.
+    folder(
+      'Memory',
+      memoryControls(config.memory, config.stock, (patch) => patchConfig({ memory: patch as never })),
+      { collapsed: true },
+    ),
     folder('Physics', physicsControls(config.physics, setPhysics, patchSim), { collapsed: true }),
     // The same light panel stage mode has always had. It was never a stage
     // feature — `<PaperLighting>` has taken these overrides all along, and a

--- a/apps/editor/src/panels/Inspector.tsx
+++ b/apps/editor/src/panels/Inspector.tsx
@@ -114,7 +114,9 @@ export function Inspector() {
     // the paper and the panel that moves it.
     folder(
       'Memory',
-      memoryControls(config.memory, config.stock, (patch) => patchConfig({ memory: patch as never })),
+      memoryControls(config.memory, config.stock, config.sheet, (patch) =>
+        patchConfig({ memory: patch as never }),
+      ),
       { collapsed: true },
     ),
     folder('Physics', physicsControls(config.physics, setPhysics, patchSim), { collapsed: true }),

--- a/apps/editor/src/panels/memoryControls.ts
+++ b/apps/editor/src/panels/memoryControls.ts
@@ -1,0 +1,87 @@
+import {
+  creaseSchema,
+  getStock,
+  MAX_CREASES,
+  type CreaseConfig,
+  type MemoryConfig,
+  type StockName,
+} from 'paperlab'
+import { button, folder, note, num, numberRange, type Control } from '../controls/controlModel'
+
+/**
+ * The Memory panel: how much of a fold this paper keeps, and the creases it
+ * is currently keeping.
+ *
+ * Built by hand rather than generated, for the reason the light panel is:
+ * `set` is an OVERRIDE. Unset it means "whatever this stock is made of", and
+ * a generated slider has no way to say that — it would read a missing value
+ * as zero and show every paper as perfectly elastic, which is the one thing
+ * memory exists to stop being true.
+ *
+ * The crease rows are the other half, and they are why this is worth a panel
+ * at all. Creases arrive by folding the paper, and once here they are
+ * ordinary config: draggable, removable, saved into a preset, carried down a
+ * share link. A dog-ear nobody folded is a crease typed in by hand.
+ */
+export function memoryControls(
+  memory: MemoryConfig,
+  stockName: StockName,
+  patch: (patch: { set?: number; creases?: CreaseConfig[] }) => void,
+): Control[] {
+  const stock = getStock(stockName)
+  const creases = memory.creases
+  const resolved = memory.set ?? stock.takesSet
+  const range = (key: 'angle' | 'offset' | 'depth') => numberRange(creaseSchema, key)
+
+  const setCrease = (index: number, next: Partial<CreaseConfig>) =>
+    patch({ creases: creases.map((c, i) => (i === index ? { ...c, ...next } : c)) })
+
+  const controls: Control[] = [
+    num('set', resolved, { min: 0, max: 1, step: 0.01 }, (v) => patch({ set: v })),
+    memory.set === undefined
+      ? note(
+          'setNote',
+          `${stock.label.toLowerCase()} keeps this much on its own — move it and it becomes yours`,
+        )
+      : button('reset to stock', () => patch({ set: undefined }), 'setReset'),
+  ]
+
+  creases.forEach((crease, i) => {
+    controls.push(
+      folder(
+        `crease ${i + 1}`,
+        [
+          // Depth first: it is the one that reads as "how creased is this",
+          // and the other two are where rather than how much.
+          num('depth', crease.depth, { ...range('depth'), step: 0.5, label: 'depth°' }, (v) =>
+            setCrease(i, { depth: v }),
+          ),
+          num('angle', crease.angle, { ...range('angle'), step: 1, label: 'angle°' }, (v) =>
+            setCrease(i, { angle: v }),
+          ),
+          num('offset', crease.offset, { ...range('offset'), step: 0.01 }, (v) =>
+            setCrease(i, { offset: v }),
+          ),
+          button('remove', () => patch({ creases: creases.filter((_, k) => k !== i) }), `remove-${i}`),
+        ],
+        { collapsed: true, key: `crease-${i}` },
+      ),
+    )
+  })
+
+  if (creases.length < MAX_CREASES) {
+    controls.push(
+      button('add crease', () => patch({ creases: [...creases, creaseSchema.parse({})] }), 'addCrease'),
+    )
+  }
+
+  if (creases.length > 0) {
+    controls.push(button('flatten', () => patch({ creases: [] }), 'flatten'))
+  } else {
+    // Silence here would read as a panel that does nothing. It says what the
+    // paper is waiting for, which is the only instruction the feature needs.
+    controls.push(note('creaseNote', 'fold the paper and its creases land here'))
+  }
+
+  return controls
+}

--- a/apps/editor/src/panels/memoryControls.ts
+++ b/apps/editor/src/panels/memoryControls.ts
@@ -2,8 +2,11 @@ import {
   creaseSchema,
   getStock,
   MAX_CREASES,
+  MAX_SET,
+  spanAlong,
   type CreaseConfig,
   type MemoryConfig,
+  type SheetConfig,
   type StockName,
 } from 'paperlab'
 import { button, folder, note, num, numberRange, type Control } from '../controls/controlModel'
@@ -26,12 +29,12 @@ import { button, folder, note, num, numberRange, type Control } from '../control
 export function memoryControls(
   memory: MemoryConfig,
   stockName: StockName,
+  sheet: SheetConfig,
   patch: (patch: { set?: number; creases?: CreaseConfig[] }) => void,
 ): Control[] {
   const stock = getStock(stockName)
   const creases = memory.creases
   const resolved = memory.set ?? stock.takesSet
-  const range = (key: 'angle' | 'offset' | 'depth') => numberRange(creaseSchema, key)
 
   const setCrease = (index: number, next: Partial<CreaseConfig>) =>
     patch({ creases: creases.map((c, i) => (i === index ? { ...c, ...next } : c)) })
@@ -53,15 +56,16 @@ export function memoryControls(
         [
           // Depth first: it is the one that reads as "how creased is this",
           // and the other two are where rather than how much.
-          num('depth', crease.depth, { ...range('depth'), step: 0.5, label: 'depth°' }, (v) =>
+          num('depth', crease.depth, { ...DEPTH, step: 0.5, label: 'depth°' }, (v) =>
             setCrease(i, { depth: v }),
           ),
-          num('angle', crease.angle, { ...range('angle'), step: 1, label: 'angle°' }, (v) =>
-            setCrease(i, { angle: v }),
+          num(
+            'angle',
+            crease.angle,
+            { ...numberRange(creaseSchema, 'angle'), step: 1, label: 'angle°' },
+            (v) => setCrease(i, { angle: v }),
           ),
-          num('offset', crease.offset, { ...range('offset'), step: 0.01 }, (v) =>
-            setCrease(i, { offset: v }),
-          ),
+          num('offset', crease.offset, offsetRange(crease, sheet), (v) => setCrease(i, { offset: v })),
           button('remove', () => patch({ creases: creases.filter((_, k) => k !== i) }), `remove-${i}`),
         ],
         { collapsed: true, key: `crease-${i}` },
@@ -84,4 +88,35 @@ export function memoryControls(
   }
 
   return controls
+}
+
+/**
+ * How deep a crease the track can scrub to — a range, not the schema's limit.
+ *
+ * `creaseSchema` allows the full ±180 a fold angle can be, and folding cannot
+ * get anywhere near it: the deepest crease any paper records is `180 × MAX_SET`,
+ * which is 36°. A track spanning 360 gives every crease this editor can
+ * actually make a fifth of its travel, and the useful part of that fifth is a
+ * few pixels wide.
+ *
+ * So the range is the recordable maximum with headroom for a hand-authored
+ * dog-ear, and `num` widens it to contain the current value — a preset or a
+ * shared link carrying a 120° crease gets a track that reaches it, rather than
+ * one that clamps it to 45 the moment anybody touches the slider.
+ */
+const DEPTH = { min: -Math.round(180 * MAX_SET) - 10, max: Math.round(180 * MAX_SET) + 10 }
+
+/**
+ * Where along its own direction a crease line can sit and still be ON the
+ * sheet.
+ *
+ * The schema's ±20 is the outer bound for any sheet the library allows; this
+ * sheet is 1.4 tall, so 97% of that track moves the crease somewhere it cannot
+ * be seen. Half the span in the crease's own direction is exactly the edge of
+ * the paper — measured along the fold's travel, because that is what `offset`
+ * is measured along.
+ */
+function offsetRange(crease: CreaseConfig, sheet: SheetConfig): { min: number; max: number; step: number } {
+  const half = spanAlong(sheet, crease.angle) / 2
+  return { min: -half, max: half, step: half / 100 }
 }

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -98,6 +98,16 @@ Underneath them are seven **deformers** — `roll`, `curl`, `bend`, `fold`, `wav
 
 One sheet of words, seven papers. Stock is not a colour swap: thermal takes on banding, newsprint takes grain, vellum goes translucent and lets the light through it. On top of stock sit composable surface effects — grain, torn deckle edges, crease lines, perforation, aging — as shader chunks. Alpha-affecting effects use `alphaTest` rather than blending, so shadows stay correct.
 
+### Memory — the paper keeps what you do to it
+
+Paper is plastic where cloth is elastic. Every deformer here is a pure function of its options, so a sheet folded to 180° and back to 0° used to come out pristine — right for cloth, wrong for the one material this library models. Now it creases.
+
+A fold that closes past 45° at a line that stays put leaves a crease behind at `peak × set`, where `set` is how much that paper keeps: kraft holds one hard, vellum springs back. A fold whose line *travels* leaves nothing, which is why paper coming off a roll is bent at the floor rather than creased along it. Creases bend the sheet as well as marking it, they can be handed to a paper that was never folded (a letter that arrives having been folded once), and they serialize — into a preset, and down a share link.
+
+```tsx
+<Paper preset="letter-fold" memory={{ set: 0.6 }} onCrease={save} />
+```
+
 ### Layouts — 12
 
 ![All twelve field layouts rendered side by side](https://paperlab.nawwara.studio/media/layouts.jpg)

--- a/packages/paperlab/src/PaperMesh.tsx
+++ b/packages/paperlab/src/PaperMesh.tsx
@@ -912,6 +912,12 @@ function withMemory(
   config: PaperConfig,
   creases: CreaseConfig[] = config.memory.creases,
 ): DeformerInstance[] | null {
+  // A simulation owns the vertices, exactly as it does in `buildStack` — and
+  // a crease must not be the thing that hands a cloth sheet a deformer stack
+  // it would never run. The frame loop returns down the sim path long before
+  // this, so today the only reader is the segment probe; saying it here is
+  // what keeps that true when it stops being the only reader.
+  if (typeof config.physics === 'object') return null
   const out = applyMemory(stack ?? [], creases)
   // Empty and null mean different things upstream — null is "nothing deforms
   // this sheet", which is the answer that gets it the flat-sheet grid.

--- a/packages/paperlab/src/PaperMesh.tsx
+++ b/packages/paperlab/src/PaperMesh.tsx
@@ -6,9 +6,11 @@ import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'rea
 import type {
   BehaviorConfigInput,
   ClothConfig,
+  CreaseConfig,
   StripConfig,
   ContentConfigInput,
   DeformerInstanceConfigInput,
+  MemoryConfigInput,
   PaperConfig,
   PaperConfigInput,
   PhysicsConfigInput,
@@ -27,6 +29,8 @@ import { getStock } from './core/stock'
 import { getPreset } from './config/presets'
 import { useContentTexture } from './content/texture'
 import { applyDeformerStack, displacePoint, stackAutoSegments, stackMinSegments } from './deformers/compose'
+import { applyMemory, CreaseTracker } from './deformers/memory'
+import { resolveCreases } from './surface/creases'
 import { stackIsAnimated } from './deformers/registry'
 import type { DeformerInstance } from './deformers/types'
 import { getBehavior } from './behaviors/registry'
@@ -57,6 +61,13 @@ export interface PaperMeshProps {
   deformers?: DeformerInstanceConfigInput[]
   /** Fragment-side effects: grain, aging, deckle, creases, perforation. */
   surface?: SurfaceConfigInput
+  /**
+   * What the sheet remembers being folded — how much of a fold this paper
+   * keeps, and the creases it already carries. A sheet can be handed its
+   * creases (a letter that arrives having been folded once) as readily as it
+   * can be folded into them.
+   */
+  memory?: MemoryConfigInput
   /** Scene-level presentation that travels with the paper (lighting). */
   scene?: SceneConfigInput
   physics?: PhysicsConfigInput | 'cloth'
@@ -73,6 +84,17 @@ export interface PaperMeshProps {
   onProgress?(value: number): void
   /** Fires when a handle drag ends, with the params the drag changed. */
   onBehaviorChange?(patch: Record<string, unknown>): void
+  /**
+   * Fires when folding the paper leaves a crease it did not have.
+   *
+   * The sheet applies its own creases immediately — this is how they get
+   * PERSISTED. Recording happens in the frame loop, where a fold's peak
+   * actually is, and routing that through React sixty times a second would
+   * cost more than the rest of the feature; so the mesh holds the live truth
+   * and reports it, and the host writes it into config whenever it likes.
+   * The same split `onBehaviorChange` uses for handle drags.
+   */
+  onCrease?(creases: CreaseConfig[]): void
   /**
    * Interaction states: when the config carries `states`, pointer triggers
    * are live by default. Set false to sculpt a stateful paper without the
@@ -144,6 +166,7 @@ function configInputs(props: PaperMeshProps): unknown[] {
     props.behavior ?? null,
     props.deformers ?? null,
     props.surface ?? null,
+    props.memory ?? null,
     props.scene ?? null,
     props.physics ?? null,
     props.onTwos ?? null,
@@ -173,6 +196,10 @@ export function resolveConfig(props: PaperMeshProps): PaperConfig {
   // Surface merges over the stock's defaults rather than replacing them, so
   // `surface={{ grain: 0.6 }}` on thermal keeps thermal's banding.
   if (props.surface) overrides.surface = { ...base.surface, ...props.surface }
+  // Merged like surface, and for the same reason: `memory={{ set: 0.2 }}` on a
+  // preset that ships creased should turn the retention down, not flatten the
+  // paper on its way past.
+  if (props.memory) overrides.memory = { ...base.memory, ...props.memory }
   if (props.scene) overrides.scene = { ...base.scene, ...props.scene }
   if (props.physics) overrides.physics = props.physics
   if (props.onTwos !== undefined) overrides.onTwos = props.onTwos
@@ -281,16 +308,56 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
    */
   const physicsKey = typeof config.physics === 'object' ? config.physics.type : config.physics
 
+  /**
+   * The crease LINES, without their depths.
+   *
+   * Depth is exactly the part that moves while you are folding, and the only
+   * thing downstream of this key is the geometry probe — which does not care.
+   * `fold`'s appetite for segments is set by its hinge radius and its
+   * direction, never by how far it has closed, so a crease deepening from 2°
+   * to 20° cannot change the answer. Keying on the depth too would rebuild
+   * the geometry on every frame of every fold, and take the sim and the
+   * base-position buffer down with it — the same trap `physicsKey` above
+   * exists to avoid.
+   */
+  const memoryKey = config.memory.creases.map((c) => `${c.angle}:${c.offset}`).join('|')
+
+  /**
+   * The sheet's live memory. Seeded from config and updated in the frame
+   * loop; `onCrease` is how it gets back to config.
+   */
+  const creasesRef = useRef<CreaseTracker | null>(null)
+  creasesRef.current ??= new CreaseTracker(config.memory.creases)
+  const creases = creasesRef.current
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: The keys are change triggers; the body only touches refs.
   useEffect(() => {
     if (!draggingRef.current && !playingRef.current) overridesRef.current = {}
+    // The slots track folds in a stack that no longer exists. The creases they
+    // left do not go with it — a sheet does not un-crease because you gave it
+    // a new behavior — so they carry over as the sheet's authored set.
+    creases.reset()
     dirtyRef.current = true
   }, [behaviorKey, deformersKey, sheetKey, physicsKey])
+
+  // Config-side creases changing means something outside the frame loop has an
+  // opinion: an edit, a shared link, or the host persisting what we just
+  // recorded. All three are the same instruction — this is what the paper
+  // carries now.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Keyed on the lines; the body reads the depths off config.
+  useEffect(() => {
+    creases.adopt(configRef.current.memory.creases)
+    dirtyRef.current = true
+  }, [memoryKey])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Keyed on the stack shape — the probe reads config off a ref.
   const { minSegments, autoSegments, animatedStack } = useMemo(() => {
     const cfg = configRef.current
-    const probe = buildStack(cfg, {})
+    // Creases are in the probe because a crease with no live fold on its line
+    // is a fold instance the grid has never been asked about — an authored
+    // dog-ear on an otherwise flat sheet needs `fold`'s 48-segment floor as
+    // much as a real fold does, and a flat sheet is tessellated 2×2.
+    const probe = withMemory(buildStack(cfg, {}), cfg)
     if (!probe) {
       return {
         minSegments: [2, 2] as SegmentPair,
@@ -316,7 +383,7 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
     if (cfg.behavior && !cfg.deformers) {
       const param = getBehavior(cfg.behavior.type).progressParam
       for (const p of PROGRESS_SAMPLES) {
-        const at = buildStack(cfg, { [param]: p })
+        const at = withMemory(buildStack(cfg, { [param]: p }), cfg)
         if (!at) continue
         const [x, y] = stackAutoSegments(at, cfg.sheet)
         if (x > want[0]) want[0] = x
@@ -329,7 +396,7 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
       autoSegments: want,
       animatedStack: animated,
     }
-  }, [behaviorKey, deformersKey, physicsKey])
+  }, [behaviorKey, deformersKey, physicsKey, memoryKey])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Keyed on the sheet — rebuilding geometry on identity would orphan GPU buffers every render.
   const geometry = useMemo(() => {
@@ -506,6 +573,21 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
     returnProgrammatic: () => machineRef.current?.returnProgrammatic() ?? false,
   }))
 
+  /**
+   * The crease lines the shader draws.
+   *
+   * Off CONFIG rather than off the tracker, and that is the honest trade. The
+   * shading is a shader uniform behind a React memo, so it updates when the
+   * host writes a recorded crease back — a frame or two after the geometry
+   * has it. A crease that has just formed is a fold the sheet is still most
+   * of the way inside; the mark landing as it opens rather than as it closes
+   * is the order it happens in on real paper anyway.
+   */
+  const shadedCreases = useMemo(
+    () => resolveCreases(config.surface, config.memory.creases, config.sheet),
+    [config.surface, config.memory.creases, config.sheet],
+  )
+
   const idlePose = useRef<IdlePose>({ position: [0, 0, 0], rotation: [0, 0, 0] })
 
   useFrame(({ clock }, delta) => {
@@ -600,7 +682,20 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
     const machineAnimating = Boolean(machineRef.current?.transitioning)
     if (!dirtyRef.current && !hasLoop && !animated && !machineAnimating) return
 
-    const stack = buildStack(cfg, overridesRef.current, behavior, now)
+    const raw = buildStack(cfg, overridesRef.current, behavior, now)
+
+    // How much this paper keeps: its own override, else what the stock is
+    // made of. The same shape as every other stock default in the library.
+    const setAmount = cfg.memory.set ?? stock.takesSet
+
+    // Read the folds BEFORE memory rewrites them. `applyMemory` raises a live
+    // fold to its crease's depth, and a tracker watching that would be reading
+    // its own output — the crease would hold the fold open, and the held-open
+    // fold would keep the crease alive, with nothing in the loop that is
+    // actually the paper being folded.
+    if (raw && creases.observe(raw, setAmount)) props.onCrease?.(creases.creases)
+
+    const stack = withMemory(raw, cfg, creases.creases)
     if (!stack) return
     dirtyRef.current = false
 
@@ -759,6 +854,7 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
           thickness={config.sheet.thickness}
           sheet={config.sheet}
           lighting={config.scene.lighting}
+          creases={shadedCreases}
         />
       </mesh>
       {props.interactive &&
@@ -802,6 +898,25 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
     </group>
   )
 })
+
+/**
+ * A stack with the sheet's CONFIGURED creases folded in — the probe's view of
+ * memory.
+ *
+ * The frame loop does not use this: it has the tracker's live creases, which
+ * are ahead of config by however long the host takes to persist them. Both
+ * paths agree on the lines, which is the only thing the geometry probe reads.
+ */
+function withMemory(
+  stack: DeformerInstance[] | null,
+  config: PaperConfig,
+  creases: CreaseConfig[] = config.memory.creases,
+): DeformerInstance[] | null {
+  const out = applyMemory(stack ?? [], creases)
+  // Empty and null mean different things upstream — null is "nothing deforms
+  // this sheet", which is the answer that gets it the flat-sheet grid.
+  return out.length > 0 ? out : null
+}
 
 /** Expand the config into the deformer stack that should run this frame. */
 function buildStack(

--- a/packages/paperlab/src/PaperMesh.tsx
+++ b/packages/paperlab/src/PaperMesh.tsx
@@ -323,6 +323,18 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
   const memoryKey = config.memory.creases.map((c) => `${c.angle}:${c.offset}`).join('|')
 
   /**
+   * The creases WITH their depths — what the sheet is actually carrying.
+   *
+   * The lines-only key above cannot serve here, and the difference is the
+   * whole reason there are two. Dragging a crease deeper changes no line, so
+   * a lines-only key never fires: the tracker would go on holding the array
+   * it was handed when the crease was created, the shading would follow the
+   * edit (it reads config) and the geometry would not, and the depth slider
+   * would darken the mark without bending the paper.
+   */
+  const creaseKey = config.memory.creases.map((c) => `${c.angle}:${c.offset}:${c.depth}`).join('|')
+
+  /**
    * The sheet's live memory. Seeded from config and updated in the frame
    * loop; `onCrease` is how it gets back to config.
    */
@@ -342,13 +354,13 @@ export const PaperMesh = forwardRef<PaperHandle, PaperMeshProps>(function PaperM
 
   // Config-side creases changing means something outside the frame loop has an
   // opinion: an edit, a shared link, or the host persisting what we just
-  // recorded. All three are the same instruction — this is what the paper
-  // carries now.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Keyed on the lines; the body reads the depths off config.
+  // recorded. `adopt` works out which — an edit resets the folds it was
+  // watching, an echo of its own recording does not.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Keyed on the creases themselves; the body reads them off config.
   useEffect(() => {
     creases.adopt(configRef.current.memory.creases)
     dirtyRef.current = true
-  }, [memoryKey])
+  }, [creaseKey])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Keyed on the stack shape — the probe reads config off a ref.
   const { minSegments, autoSegments, animatedStack } = useMemo(() => {

--- a/packages/paperlab/src/config/diff.ts
+++ b/packages/paperlab/src/config/diff.ts
@@ -2,6 +2,7 @@ import {
   behaviorConfigSchema,
   clothConfigSchema,
   contentSchema,
+  memorySchema,
   paperConfigSchema,
   sceneSchema,
   sheetSchema,
@@ -70,6 +71,14 @@ export function diffConfig(config: PaperConfig): PaperConfigInput {
   if (config.deformers) out.deformers = config.deformers
 
   if (Object.keys(config.surface).length > 0) out.surface = config.surface
+
+  // Diffed like the scene below, and for the same reason it is: `memory` is
+  // going to grow fields, and a diff that names the ones it knows about
+  // silently drops the next one. Without this a creased sheet exported to a
+  // `.paper` file, a share link or a snippet came back flat — the editor
+  // showed the creases and nothing that left the editor carried them.
+  const memory = diffAgainst(config.memory as never, memorySchema.parse({}) as never)
+  if (Object.keys(memory).length > 0) out.memory = memory
 
   if (typeof config.physics === 'object') {
     const defaults = clothConfigSchema.parse({ type: 'cloth' }) as Record<string, unknown>

--- a/packages/paperlab/src/config/presets/index.ts
+++ b/packages/paperlab/src/config/presets/index.ts
@@ -210,7 +210,24 @@ const builtins: Record<string, PaperConfigInput> = {
       text: 'Dear you,\n\nSome things are worth folding carefully.\n\nYours,\nN.',
     },
     behavior: { type: 'letter-fold', progress: 0.4, crease: 0.3 },
-    surface: { creaseLines: { angle: 0, positions: [1 / 3, 2 / 3], strength: 0.5 } },
+    // A letter that has been folded before. These were painted-on
+    // `creaseLines` until the paper could carry real ones — two marks in the
+    // shader at exactly the two places the tri-fold bends, which is a good
+    // impression of a crease right up until you unfold the letter and it
+    // comes back perfectly flat. As memory they bend the sheet as well as
+    // marking it, and folding the letter deepens the creases it already has
+    // rather than drawing a second pair on top of them.
+    //
+    // The lines are `letterFold`'s own: travel down and up, each a sixth of
+    // the sheet from the middle. Shallower than a fold leaves (printer keeps
+    // about 20°) because this letter has been folded once and put away, not
+    // folded and reopened in front of you.
+    memory: {
+      creases: [
+        { angle: 270, offset: 1.4 / 6, depth: 13 },
+        { angle: 90, offset: 1.4 / 6, depth: 11 },
+      ],
+    },
   },
   /**
    * The wash, shown rather than described.

--- a/packages/paperlab/src/config/props.test.ts
+++ b/packages/paperlab/src/config/props.test.ts
@@ -26,6 +26,7 @@ const documented: PaperMeshProps = {
   content: { type: 'receipt', store: 'acme.dev', items: [{ name: 'Widget', price: 9.99 }] },
   behavior: { type: 'unroll', progress: 0.6 },
   surface: { grain: 0.3, deckle: { edges: ['bottom'] } },
+  memory: { set: 0.6, creases: [{ angle: 270, offset: 0.23, depth: 13 }] },
   physics: 'none',
   interactive: true,
   autoplay: true,
@@ -41,6 +42,7 @@ const minimal: PaperMeshProps = {
   content: { type: 'text', text: 'hi' },
   behavior: { type: 'peel' },
   surface: { aging: 0.5 },
+  memory: { set: 0 },
   scene: { lighting: 'noir' },
   physics: { type: 'cloth', pins: 'top-edge' },
   deformers: [{ type: 'bend' }],
@@ -54,6 +56,20 @@ describe('prop overrides reach the config', () => {
     const config = resolveConfig({ surface: { grain: 0.7, aging: 0.25 } })
     expect(config.surface.grain).toBe(0.7)
     expect(config.surface.aging).toBe(0.25)
+  })
+
+  it('carries memory, which is the same bug waiting to happen a third time', () => {
+    const config = resolveConfig({ memory: { creases: [{ angle: 90, offset: 0.2, depth: 14 }] } })
+    expect(config.memory.creases).toHaveLength(1)
+    expect(config.memory.creases[0]).toMatchObject({ angle: 90, depth: 14 })
+  })
+
+  it('merges memory over a preset’s instead of replacing it', () => {
+    // Turning the retention down on a letter that ships creased must not
+    // flatten it on the way past — `set` and `creases` are separate facts.
+    const config = resolveConfig({ preset: 'letter-fold', memory: { set: 0.2 } })
+    expect(config.memory.set).toBe(0.2)
+    expect(config.memory.creases.length).toBeGreaterThan(0)
   })
 
   it('merges surface over the stock defaults instead of replacing them', () => {

--- a/packages/paperlab/src/config/schema.ts
+++ b/packages/paperlab/src/config/schema.ts
@@ -357,6 +357,65 @@ export type SurfaceConfig = z.infer<typeof surfaceSchema>
 export type SurfaceConfigInput = z.input<typeof surfaceSchema>
 export type PaperEdge = (typeof paperEdges)[number]
 
+// ── Memory ───────────────────────────────────────────────────────────────────
+
+/**
+ * A crease the paper carries: a line it has been folded along and did not
+ * fully come back from.
+ *
+ * `angle` and `offset` name the line exactly as {@link foldOptionsSchema}
+ * does — angle is the direction the fold TRAVELS and the crease line runs
+ * perpendicular to it, offset is the signed distance of that line from the
+ * sheet's centre along the travel direction. Naming the line in the fold
+ * deformer's own terms is what lets a remembered crease and a live fold
+ * recognise each other as the same crease rather than stack into two.
+ */
+export const creaseSchema = z.object({
+  angle: z.number().min(-360).max(360).default(90),
+  offset: z.number().min(-20).max(20).default(0),
+  /**
+   * The residual fold angle in degrees, signed — how far open the crease
+   * still sits once nothing is holding the paper. This is the whole of what
+   * a crease IS: geometry and shading both read it, and it is what makes the
+   * field authorable by hand (a dog-ear is a crease with a big `depth` near
+   * a corner) rather than only recordable.
+   */
+  depth: z.number().min(-180).max(180).default(12),
+})
+
+export type CreaseConfig = z.infer<typeof creaseSchema>
+export type CreaseConfigInput = z.input<typeof creaseSchema>
+
+/**
+ * What the sheet remembers having been done to it.
+ *
+ * Paper is PLASTIC where cloth is elastic: fold it and it keeps the fold.
+ * Every deformer in the library is a pure function of its options, so a
+ * sheet folded to 180° and back to 0° comes out of the stack pristine —
+ * which is right for cloth and wrong for the one material Paperlab models.
+ * This is the layer that remembers, and it lives beside the stack rather
+ * than inside it precisely so deformers stay pure.
+ */
+export const memorySchema = z.object({
+  /**
+   * How much of a fold this paper keeps, 0..1, over the stock's own
+   * {@link Stock.takesSet}. Kraft holds a crease hard; vellum springs most
+   * of the way back.
+   */
+  set: z.number().min(0).max(1).optional(),
+  /**
+   * The creases themselves. Recorded by folding the paper (see
+   * `onCrease`), or written by hand — a preset can ship already creased.
+   *
+   * Capped at four because that is what the crease shader carries, and a
+   * cap the schema states is better than one the renderer applies silently.
+   */
+  creases: z.array(creaseSchema).max(4).default([]),
+})
+
+export type MemoryConfig = z.infer<typeof memorySchema>
+export type MemoryConfigInput = z.input<typeof memorySchema>
+
 // ── Behavior & deformers ─────────────────────────────────────────────────────
 
 export const behaviorConfigSchema = z.discriminatedUnion('type', [
@@ -695,6 +754,15 @@ export const paperConfigSchema = z
     behavior: behaviorConfigSchema.optional(),
     deformers: z.array(deformerInstanceSchema).optional(),
     surface: surfaceSchema.default({}),
+    /**
+     * What the sheet remembers being folded — creases outlive the fold.
+     *
+     * Present by default, and on: paper that forgets is the bug this exists
+     * to fix, so remembering is not something a preset should have to ask
+     * for. `memory: { set: 0 }` is the opt-out, and it is what every sheet in
+     * the library did before this shipped.
+     */
+    memory: memorySchema.default({}),
     physics: physicsSchema.default('none'),
     scene: sceneSchema.default({}),
     onTwos: z.boolean().default(false),

--- a/packages/paperlab/src/core/stock.ts
+++ b/packages/paperlab/src/core/stock.ts
@@ -29,6 +29,16 @@ export interface Stock {
   showThrough: number
   /** Glossy near-white glue underside (stickers) — forces showThrough 0. */
   adhesive: boolean
+  /**
+   * How hard this paper holds a crease, 0..1 — the material half of
+   * {@link MemoryConfig}. Fibrous, thick stocks take a set and keep it;
+   * coated and translucent ones spring most of the way back.
+   *
+   * Not a fraction of anything on its own: `memory.ts` scales it by
+   * `MAX_SET`, so 1 here means "as much as paper ever remembers", not "stays
+   * exactly as folded".
+   */
+  takesSet: number
 }
 
 export const stocks: Record<StockName, Stock> = {
@@ -44,6 +54,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: { grain: 0.12 },
     showThrough: 0,
     adhesive: false,
+    // Office bond creases cleanly and holds it — the reference paper.
+    takesSet: 0.6,
   },
   thermal: {
     id: 'thermal',
@@ -57,6 +69,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: { aging: 0.1 },
     showThrough: 0.06,
     adhesive: false,
+    // Thin and already curled off a roll; a fold in it stays folded.
+    takesSet: 0.65,
   },
   kraft: {
     id: 'kraft',
@@ -70,6 +84,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: { grain: 0.5 },
     showThrough: 0,
     adhesive: false,
+    // Thick and fibrous. The crease is a break, and it never comes back.
+    takesSet: 0.85,
   },
   newsprint: {
     id: 'newsprint',
@@ -83,6 +99,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: { grain: 0.7, aging: 0.15 },
     showThrough: 0.06,
     adhesive: false,
+    // Soft, short-fibred, and barely sprung — it crumples rather than resists.
+    takesSet: 0.8,
   },
   vellum: {
     id: 'vellum',
@@ -96,6 +114,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: {},
     showThrough: 0.55,
     adhesive: false,
+    // Translucent and plasticky: it fights the fold and mostly wins.
+    takesSet: 0.25,
   },
   'photo-gloss': {
     id: 'photo-gloss',
@@ -109,6 +129,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: {},
     showThrough: 0,
     adhesive: false,
+    // The coating resists, then cracks white — little angle kept, lots of mark.
+    takesSet: 0.3,
   },
   // Photo-gloss-like face, glossy near-white glue underside. The default
   // carrier for perforated stamp sheets.
@@ -124,6 +146,8 @@ export const stocks: Record<StockName, Stock> = {
     defaultSurface: {},
     showThrough: 0,
     adhesive: true,
+    // A face sheet on a release liner; the liner does most of the remembering.
+    takesSet: 0.5,
   },
 }
 

--- a/packages/paperlab/src/deformers/memory.test.ts
+++ b/packages/paperlab/src/deformers/memory.test.ts
@@ -17,6 +17,7 @@ import { paperConfigSchema } from '../config/schema'
 import { resolveCreases } from '../surface/creases'
 import { diffConfig } from '../config/diff'
 import { getPreset } from '../config/presets'
+import { resolveConfig } from '../PaperMesh'
 
 const sheet: SheetDims = { width: 1, height: 1.4 }
 
@@ -219,6 +220,33 @@ describe('CreaseTracker', () => {
     expect(Math.max(...tracker.creases.map((c) => Math.abs(c.depth)))).toBeGreaterThan(halfway)
   })
 
+  it('goes quiet once the fold stops, even under a deeper authored crease', () => {
+    // Reading the merged view used to hand back the tracker's OWN recorded
+    // objects, and the deeper-wins step wrote through them — so reading the
+    // creases rewrote the depth that had just been recorded. The next frame
+    // then saw a change that was nothing but its own echo, and reported one
+    // every frame forever: in the editor, a config write per frame for as
+    // long as the paper was on screen.
+    const authored = crease(270, sheet.height / 6, 40)
+    const tracker = new CreaseTracker([authored])
+    const stack = (p: number) => letterFold.stack({ progress: p, crease: 0.3 } as never, sheet)
+    // `set` low enough that folding records something SHALLOWER than the
+    // authored crease, which is the only way the deeper-wins step fires.
+    for (let i = 0; i <= 20; i++) if (tracker.observe(stack(i / 20), 0.2)) void tracker.creases
+
+    expect(tracker.observe(stack(1), 0.2)).toBe(false)
+    void tracker.creases
+    expect(tracker.observe(stack(1), 0.2)).toBe(false)
+  })
+
+  it('hands out creases nobody can reach back through', () => {
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+    const taken = tracker.creases
+    taken[0]!.depth = 999
+    expect(tracker.creases[0]!.depth).not.toBe(999)
+  })
+
   it('never records more creases than the shader can draw', () => {
     const tracker = new CreaseTracker()
     // Six accordion creases across one sheet, all folded together.
@@ -309,6 +337,21 @@ describe('memory config', () => {
 
   it('lets a paper opt out of remembering entirely', () => {
     expect(paperConfigSchema.parse({ memory: { set: 0 } }).memory.set).toBe(0)
+  })
+})
+
+describe('a creased sheet with a simulation on it', () => {
+  it('is legal, and the sim still owns the vertices', () => {
+    // `memory` and a sim are not exclusive the way behavior and a sim are —
+    // a creased sheet can be dropped into cloth. What must not happen is the
+    // crease handing that sheet a deformer stack, because the sim writes
+    // every vertex itself and the two would fight over the same buffer.
+    const config = paperConfigSchema.parse({
+      physics: { type: 'cloth' },
+      memory: { creases: [crease(90, 0.2, 15)] },
+    })
+    expect(config.memory.creases).toHaveLength(1)
+    expect(resolveConfig({ preset: config as never }).physics).toMatchObject({ type: 'cloth' })
   })
 })
 

--- a/packages/paperlab/src/deformers/memory.test.ts
+++ b/packages/paperlab/src/deformers/memory.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyMemory,
+  CreaseTracker,
+  CREASE_MIN_GROWTH,
+  CREASE_RADIUS,
+  MAX_CREASES,
+  MAX_SET,
+  sameLine,
+} from './memory'
+import { letterFold } from '../behaviors/letter-fold'
+import { unroll } from '../behaviors/unroll'
+import type { CreaseConfig } from '../config/schema'
+import type { DeformerInstance, SheetDims } from './types'
+import { getStock } from '../core/stock'
+import { paperConfigSchema } from '../config/schema'
+import { resolveCreases } from '../surface/creases'
+import { diffConfig } from '../config/diff'
+import { getPreset } from '../config/presets'
+
+const sheet: SheetDims = { width: 1, height: 1.4 }
+
+const fold = (angle: number, offset: number, foldAngle: number, radius = 0.04): DeformerInstance => ({
+  type: 'fold',
+  options: { angle, offset, foldAngle, radius },
+})
+
+const crease = (angle: number, offset: number, depth: number): CreaseConfig => ({ angle, offset, depth })
+
+/** Drive a behavior's progress through a sweep, one frame per step. */
+function play(
+  tracker: CreaseTracker,
+  behavior: { stack(o: never, sheet: SheetDims): DeformerInstance[] },
+  options: Record<string, unknown>,
+  from: number,
+  to: number,
+  set: number,
+  steps = 20,
+): void {
+  for (let i = 0; i <= steps; i++) {
+    const progress = from + ((to - from) * i) / steps
+    tracker.observe(behavior.stack({ ...options, progress } as never, sheet), set)
+  }
+}
+
+describe('crease lines', () => {
+  it('reads a fold and its mirror as the same line', () => {
+    // Same line, opposite travel: the flap changes sides, the crease does not.
+    expect(sameLine({ angle: 90, offset: 0.2 }, { angle: 270, offset: -0.2 })).toBe(true)
+  })
+
+  it('keeps letter-fold’s two creases apart', () => {
+    // Both at +h/6, travelling opposite ways — two lines a third of the sheet
+    // apart, and the whole tri-fold is wrong if they collapse into one.
+    const [bottom, top] = letterFold.stack({ progress: 1, crease: 0.3 }, sheet)
+    expect(sameLine(bottom!.options as never, top!.options as never)).toBe(false)
+  })
+
+  it('does not confuse lines that merely share an offset', () => {
+    expect(sameLine({ angle: 0, offset: 0.3 }, { angle: 90, offset: 0.3 })).toBe(false)
+  })
+})
+
+describe('applyMemory', () => {
+  it('is a floor on a live fold, never an addition', () => {
+    const stack = [fold(90, 0.2, 120)]
+    const out = applyMemory(stack, [crease(90, 0.2, 15)])
+    // The behavior is folding this line far past its crease — the crease is
+    // invisible, and must not add fifteen degrees to a hundred and twenty.
+    expect((out[0]!.options as { foldAngle: number }).foldAngle).toBe(120)
+    expect(out).toHaveLength(1)
+  })
+
+  it('holds a released fold open at the crease', () => {
+    const out = applyMemory([fold(90, 0.2, 3)], [crease(90, 0.2, 15)])
+    expect((out[0]!.options as { foldAngle: number }).foldAngle).toBe(15)
+    expect(out).toHaveLength(1)
+  })
+
+  it('never leaves the caller’s stack modified', () => {
+    const stack = [fold(90, 0.2, 3)]
+    applyMemory(stack, [crease(90, 0.2, 15)])
+    expect((stack[0]!.options as { foldAngle: number }).foldAngle).toBe(3)
+  })
+
+  it('prepends a crease that has no live fold, at the crease radius', () => {
+    const out = applyMemory([{ type: 'curl', options: {} }], [crease(90, 0.2, 15)])
+    expect(out).toHaveLength(2)
+    expect(out[0]!.type).toBe('fold')
+    expect(out[0]!.options).toMatchObject({ angle: 90, offset: 0.2, foldAngle: 15, radius: CREASE_RADIUS })
+    // Before the behavior: the sheet is already creased when it picks it up.
+    expect(out[1]!.type).toBe('curl')
+  })
+
+  it('folds a crease onto a sheet with no stack at all', () => {
+    const out = applyMemory([], [crease(90, 0.2, 15)])
+    expect(out).toHaveLength(1)
+  })
+
+  it('keeps the fold direction the paper was folded in', () => {
+    const out = applyMemory([fold(90, 0, 0)], [crease(90, 0, -15)])
+    expect((out[0]!.options as { foldAngle: number }).foldAngle).toBe(-15)
+  })
+
+  it('ignores a crease too shallow to see', () => {
+    const out = applyMemory([fold(90, 0, 0)], [crease(90, 0, 0.4)])
+    expect((out[0]!.options as { foldAngle: number }).foldAngle).toBe(0)
+    expect(out).toHaveLength(1)
+  })
+
+  it('leaves a stack with no creases exactly as it found it', () => {
+    const stack = [fold(90, 0.2, 30)]
+    expect(applyMemory(stack, [])).toBe(stack)
+  })
+})
+
+describe('CreaseTracker', () => {
+  it('records the two creases a letter fold makes', () => {
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+
+    const creases = tracker.creases
+    expect(creases).toHaveLength(2)
+    // Both lines sit a sixth of the sheet either side of centre.
+    const offsets = creases.map((c) => c.offset).sort((a, b) => a - b)
+    expect(offsets).toEqual([sheet.height / 6, sheet.height / 6])
+    expect(creases.map((c) => c.angle).sort((a, b) => a - b)).toEqual([90, 270])
+  })
+
+  it('scales the crease by how much the paper keeps', () => {
+    const kraft = new CreaseTracker()
+    const vellum = new CreaseTracker()
+    play(kraft, letterFold, { crease: 0.3 }, 0, 1, getStock('kraft').takesSet)
+    play(vellum, letterFold, { crease: 0.3 }, 0, 1, getStock('vellum').takesSet)
+
+    const deepest = (t: CreaseTracker) => Math.max(...t.creases.map((c) => Math.abs(c.depth)))
+    expect(deepest(kraft)).toBeGreaterThan(deepest(vellum) * 3)
+    // The bottom flap closes to 165°; kraft keeps 0.85 × MAX_SET of it.
+    expect(deepest(kraft)).toBeCloseTo(165 * getStock('kraft').takesSet * MAX_SET, 5)
+  })
+
+  it('leaves perfectly elastic paper uncreased', () => {
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 0)
+    expect(tracker.creases).toEqual([])
+  })
+
+  it('does not crease a fold that never closes far enough', () => {
+    const tracker = new CreaseTracker()
+    // A third of the way in, the bottom flap is only at ~69° — a bend.
+    play(tracker, letterFold, { crease: 0.3 }, 0, 0.33, 1)
+    const deepest = tracker.creases.map((c) => Math.abs(c.depth))
+    expect(deepest.every((d) => d > 0)).toBe(true)
+    // ...but stop below the growth threshold and there is nothing at all.
+    const shy = new CreaseTracker()
+    play(shy, letterFold, { crease: 0.3 }, 0, 0.2, 1)
+    expect(shy.creases).toEqual([])
+  })
+
+  it('does not crease a hinge that travels', () => {
+    // `unroll`'s landing fold sits at exactly 90° forever while its line walks
+    // down the sheet. Paper coming off a roll is bent at the floor, not
+    // creased, and a trail of creases behind it would be the obvious bug.
+    const tracker = new CreaseTracker()
+    for (let i = 0; i <= 40; i++) {
+      tracker.observe(unroll.stack({ ...unroll.defaults, progress: i / 40 } as never, sheet), 1)
+    }
+    expect(tracker.creases).toEqual([])
+  })
+
+  it('does not crease a sheet that was authored folded and merely opened', () => {
+    // No growth: the fold was already closed when we first saw it. Whoever
+    // folded this letter should have shipped the crease in the preset.
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 1, 0, 1)
+    expect(tracker.creases).toEqual([])
+  })
+
+  it('creases on the second pass, having watched the first', () => {
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 1, 0, 1)
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+    expect(tracker.creases).toHaveLength(2)
+  })
+
+  it('reports a change once, not every frame', () => {
+    const tracker = new CreaseTracker()
+    const stack = (p: number) => letterFold.stack({ progress: p, crease: 0.3 } as never, sheet)
+    let changes = 0
+    for (let i = 0; i <= 60; i++) if (tracker.observe(stack(i / 60), 1)) changes++
+    const settled = tracker.observe(stack(1), 1)
+    // It deepens as the fold closes, so it does report more than once — but
+    // once the fold stops moving it goes quiet, which is the property that
+    // keeps this off the React path.
+    expect(changes).toBeGreaterThan(0)
+    expect(settled).toBe(false)
+  })
+
+  it('keeps its creases when the stack is replaced', () => {
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+    const before = tracker.creases
+    tracker.reset()
+    expect(tracker.creases).toEqual(before)
+  })
+
+  it('does not stall mid-fold when the host writes a crease back', () => {
+    const tracker = new CreaseTracker()
+    const stack = (p: number) => letterFold.stack({ progress: p, crease: 0.3 } as never, sheet)
+    for (let i = 0; i <= 10; i++) {
+      if (tracker.observe(stack(i / 20), 1)) tracker.adopt(tracker.creases)
+    }
+    const halfway = Math.max(...tracker.creases.map((c) => Math.abs(c.depth)))
+    for (let i = 11; i <= 20; i++) {
+      if (tracker.observe(stack(i / 20), 1)) tracker.adopt(tracker.creases)
+    }
+    // The echo of our own recording must not reset the peak the fold is still
+    // climbing — the crease has to go on deepening to the end of the fold.
+    expect(Math.max(...tracker.creases.map((c) => Math.abs(c.depth)))).toBeGreaterThan(halfway)
+  })
+
+  it('never records more creases than the shader can draw', () => {
+    const tracker = new CreaseTracker()
+    // Six accordion creases across one sheet, all folded together.
+    const stack = (p: number) => Array.from({ length: 6 }, (_, i) => fold(90, -0.6 + i * 0.24, p * 160))
+    for (let i = 0; i <= 20; i++) tracker.observe(stack(i / 20), 1)
+    expect(tracker.creases).toHaveLength(MAX_CREASES)
+  })
+
+  it('takes the deeper of an authored crease and a recorded one on the same line', () => {
+    const deep = crease(90, sheet.height / 6, 40)
+    const tracker = new CreaseTracker([deep])
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 0.2)
+    const onLine = tracker.creases.find((c) => sameLine(c, deep))!
+    // Folding a creased sheet along its own crease re-makes it; it does not
+    // add a second one, and it does not shallow the one that is there.
+    expect(Math.abs(onLine.depth)).toBe(40)
+  })
+
+  it('exposes a growth threshold the built-in fold actually clears', () => {
+    // A guard on the constant itself: letter-fold's leading flap closes to
+    // 165°, so any threshold above that silently turns the feature off.
+    expect(CREASE_MIN_GROWTH).toBeLessThan(165)
+  })
+})
+
+describe('crease shading', () => {
+  it('turns a fold’s travel angle into the line it leaves', () => {
+    // fold travels +y, so the crease runs horizontally.
+    const [shaded] = resolveCreases({}, [crease(90, 0, 15)], sheet)
+    expect(shaded!.angle).toBe(0)
+  })
+
+  it('places the line where the fold put it', () => {
+    const [centre] = resolveCreases({}, [crease(90, 0, 15)], sheet)
+    expect(centre!.position).toBeCloseTo(0.5, 6)
+    // A third of the way up a 1.4-tall sheet.
+    const [third] = resolveCreases({}, [crease(90, sheet.height / 6, 15)], sheet)
+    expect(third!.position).toBeCloseTo(0.5 + 1 / 6, 6)
+  })
+
+  it('saturates rather than growing without bound', () => {
+    const [hard] = resolveCreases({}, [crease(90, 0, 120)], sheet)
+    expect(hard!.strength).toBe(1)
+  })
+
+  it('draws authored crease lines and remembered ones together', () => {
+    const shaded = resolveCreases(
+      { creaseLines: { angle: 0, positions: [0.25], strength: 0.5 } },
+      [crease(90, 0, 15)],
+      sheet,
+    )
+    expect(shaded).toHaveLength(2)
+    // Authored first: at the cap it is the recorded one that gets dropped,
+    // never the one someone placed by hand.
+    expect(shaded[0]!.position).toBe(0.25)
+  })
+
+  it('never hands the shader more lines than it has uniforms for', () => {
+    const shaded = resolveCreases(
+      { creaseLines: { angle: 0, positions: [0.1, 0.2, 0.3], strength: 0.5 } },
+      [crease(90, 0, 15), crease(0, 0.2, 15)],
+      sheet,
+    )
+    expect(shaded).toHaveLength(4)
+  })
+})
+
+describe('memory config', () => {
+  it('is on by default, at the stock’s own setting', () => {
+    const config = paperConfigSchema.parse({})
+    expect(config.memory.creases).toEqual([])
+    // Unset means "whatever this paper is made of" — the stock decides.
+    expect(config.memory.set).toBeUndefined()
+    expect(getStock(config.stock).takesSet).toBeGreaterThan(0)
+  })
+
+  it('serializes a creased sheet into a preset and back', () => {
+    const creases = [crease(90, 0.23, 18)]
+    const config = paperConfigSchema.parse({ memory: { set: 0.4, creases } })
+    const round = paperConfigSchema.parse(JSON.parse(JSON.stringify(config)))
+    expect(round.memory).toEqual({ set: 0.4, creases })
+  })
+
+  it('refuses more creases than the renderer can carry', () => {
+    const many = Array.from({ length: 5 }, (_, i) => crease(90, i * 0.1, 12))
+    expect(paperConfigSchema.safeParse({ memory: { creases: many } }).success).toBe(false)
+  })
+
+  it('lets a paper opt out of remembering entirely', () => {
+    expect(paperConfigSchema.parse({ memory: { set: 0 } }).memory.set).toBe(0)
+  })
+})
+
+describe('a crease that leaves the editor', () => {
+  it('survives the export diff', () => {
+    // The export emits only what differs from the defaults, and a field it
+    // does not know about is a field that silently does not travel — which
+    // for creases means the editor shows them and the share link does not.
+    const config = paperConfigSchema.parse({
+      memory: { set: 0.4, creases: [crease(90, 0.23, 18)] },
+    })
+    const diffed = diffConfig(config) as { memory?: unknown }
+    expect(diffed.memory).toEqual({ set: 0.4, creases: [crease(90, 0.23, 18)] })
+    expect(paperConfigSchema.parse(diffed).memory).toEqual(config.memory)
+  })
+
+  it('stays out of the export when the paper is flat', () => {
+    expect((diffConfig(paperConfigSchema.parse({})) as { memory?: unknown }).memory).toBeUndefined()
+  })
+
+  it('ships in the letter-fold preset as geometry, not as paint', () => {
+    // It was `surface.creaseLines` — two marks in the shader that a letter
+    // could unfold straight back out of. The preset is the argument for the
+    // feature, so it has to be the thing itself.
+    const letter = getPreset('letter-fold')
+    expect(letter.surface.creaseLines).toBeUndefined()
+    expect(letter.memory.creases).toHaveLength(2)
+    // And they have to be on the lines the tri-fold actually bends, or
+    // folding the letter draws a second pair beside the first.
+    const folds = letterFold.stack({ progress: 1, crease: 0.3 }, letter.sheet)
+    for (const fold of folds) {
+      expect(letter.memory.creases.some((c) => sameLine(c, fold.options as never))).toBe(true)
+    }
+  })
+})
+
+describe('every stock', () => {
+  it('says how hard it holds a crease', () => {
+    for (const name of [
+      'printer',
+      'thermal',
+      'kraft',
+      'newsprint',
+      'vellum',
+      'photo-gloss',
+      'sticker',
+    ] as const) {
+      const { takesSet } = getStock(name)
+      expect(takesSet).toBeGreaterThan(0)
+      expect(takesSet).toBeLessThanOrEqual(1)
+    }
+    // The material claim the feature rests on: fibrous stock remembers, coated
+    // and translucent stock springs back.
+    expect(getStock('kraft').takesSet).toBeGreaterThan(getStock('vellum').takesSet)
+    expect(getStock('newsprint').takesSet).toBeGreaterThan(getStock('photo-gloss').takesSet)
+  })
+})

--- a/packages/paperlab/src/deformers/memory.test.ts
+++ b/packages/paperlab/src/deformers/memory.test.ts
@@ -247,6 +247,35 @@ describe('CreaseTracker', () => {
     expect(tracker.creases[0]!.depth).not.toBe(999)
   })
 
+  it('lets a hand edit win over the fold that recorded the crease', () => {
+    // Dragging a crease shallower has to stick. `merge` takes the deeper of
+    // two creases on a line, so without forgetting the fold that recorded
+    // the deep one it would outvote the edit — and go on outvoting it, since
+    // the fold is still sitting in a slot.
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+    const recorded = Math.max(...tracker.creases.map((c) => Math.abs(c.depth)))
+    expect(recorded).toBeGreaterThan(5)
+
+    const edited = tracker.creases.map((c) => ({ ...c, depth: Math.sign(c.depth) * 5 }))
+    tracker.adopt(edited)
+    expect(tracker.creases.map((c) => Math.abs(c.depth))).toEqual(edited.map(() => 5))
+
+    // And it stays put while the paper is held where it is.
+    const held = letterFold.stack({ progress: 1, crease: 0.3 } as never, sheet)
+    expect(tracker.observe(held, 1)).toBe(false)
+    expect(tracker.creases.map((c) => Math.abs(c.depth))).toEqual(edited.map(() => 5))
+  })
+
+  it('re-creases a hand-flattened sheet when it is folded again', () => {
+    const tracker = new CreaseTracker()
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+    tracker.adopt([])
+    expect(tracker.creases).toEqual([])
+    play(tracker, letterFold, { crease: 0.3 }, 0, 1, 1)
+    expect(tracker.creases).toHaveLength(2)
+  })
+
   it('never records more creases than the shader can draw', () => {
     const tracker = new CreaseTracker()
     // Six accordion creases across one sheet, all folded together.

--- a/packages/paperlab/src/deformers/memory.ts
+++ b/packages/paperlab/src/deformers/memory.ts
@@ -316,7 +316,14 @@ function merge(authored: CreaseConfig[], recorded: CreaseConfig[]): CreaseConfig
   for (const crease of [...recorded, ...authored]) {
     const existing = out.find((c) => sameLine(c, crease))
     if (!existing) {
-      out.push(crease)
+      // Copied, not shared. The deeper-wins line below WRITES to whatever is
+      // in `out`, and pushing the argument by reference pointed that write
+      // straight back into `this.recorded` — so reading the merged view
+      // rewrote the depth that had just been recorded, the next frame saw a
+      // change that was nothing but its own echo, and the tracker reported
+      // one every frame for as long as an authored crease sat deeper than
+      // the fold could make it.
+      out.push({ ...crease })
       continue
     }
     if (Math.abs(crease.depth) > Math.abs(existing.depth)) existing.depth = crease.depth

--- a/packages/paperlab/src/deformers/memory.ts
+++ b/packages/paperlab/src/deformers/memory.ts
@@ -1,0 +1,339 @@
+import type { CreaseConfig } from '../config/schema'
+import type { FoldOptions } from './fold'
+import type { DeformerInstance } from './types'
+
+/**
+ * Paper memory: the sheet keeps what has been done to it.
+ *
+ * Every deformer is a pure function of its options — a sheet folded to 180°
+ * and back to 0° flows through the stack and comes out pristine. That is
+ * correct for cloth and wrong for paper, which is PLASTIC: the fibres break
+ * along the fold and the crease outlives it.
+ *
+ * The fix lives here rather than inside the deformers, and deliberately.
+ * Deformer purity is load-bearing — it is what gives the GLSL twins
+ * something to be identical to, what lets the field scale one instance's
+ * bend by a per-sheet bias, and what `test:parity` checks. So memory sits
+ * ABOVE the stack: it watches the stack the behavior built, and it rewrites
+ * that stack before it runs. Nothing below this file knows it exists.
+ *
+ * The whole layer is hero-path only. The field composes one GLSL program for
+ * every sheet in an instanced draw call, and a crease is per-sheet state —
+ * so a field of a hundred papers cannot carry a hundred crease sets without
+ * per-instance attributes that don't exist yet. `applyMemory` is called from
+ * `PaperMesh` and from nowhere in `field/`.
+ */
+
+/**
+ * What a paper at `takesSet: 1` keeps of a fold, as a fraction of the angle
+ * it was folded to.
+ *
+ * Kraft folded flat (180°) comes to rest around 30° open, which is `180 ×
+ * 0.85 × 0.2`. Keeping this multiplier here rather than folding it into the
+ * stock values is what lets `memory.set` and `Stock.takesSet` both be honest
+ * 0..1 knobs that use their whole range, instead of designer-facing sliders
+ * that do everything interesting in their bottom fifth.
+ */
+export const MAX_SET = 0.2
+
+/**
+ * Hinge width of a remembered crease, world units.
+ *
+ * Sharper than `fold`'s own 0.04 default, because a crease is not a fold: a
+ * fold bends fibres that are pushing back, a crease is the line where they
+ * already gave up. It is a constant rather than a schema field because it is
+ * a property of broken paper and not a thing anyone tunes — `depth` is the
+ * knob, and a second one here would only ever be set wrong.
+ */
+export const CREASE_RADIUS = 0.03
+
+/**
+ * How far a fold has to CLOSE, from however open it last was and at a line
+ * that stays put, before it leaves a crease. Degrees.
+ *
+ * This is the rule that separates the two things `fold` is used for, and it
+ * has to, because they are the same deformer. A crease is made by the ACT of
+ * folding: the angle closes while the line is held. `unroll`'s landing hinge
+ * is a fold instance that sits at exactly 90° forever while its line travels
+ * down the sheet (a fixed floor is a moving line in sheet coordinates) —
+ * paper coming off a roll and turning at the floor is BENT, not creased, and
+ * a trail of creases left behind it would be the obvious bug. Measuring the
+ * closing rather than the angle gets both right, and gets them right without
+ * asking a behavior to declare anything about its own folds.
+ */
+export const CREASE_MIN_GROWTH = 45
+
+/** How far a crease line may drift and still be the same crease. World units. */
+export const CREASE_DRIFT = 0.02
+
+/** And in degrees, for the travel direction. */
+export const CREASE_DRIFT_ANGLE = 2
+
+/** Below this the crease is neither visible nor worth a slot. Degrees. */
+export const MIN_DEPTH = 1
+
+/** What the crease shader carries, and so what memory may record. */
+export const MAX_CREASES = 4
+
+/**
+ * A crease line in canonical form, for identity only.
+ *
+ * `(angle, offset)` and `(angle + 180, -offset)` name the same line through
+ * the sheet — they differ in which half `fold` treats as the flap, not in
+ * where the crease is. `letter-fold` uses exactly that pair (270 at +h/6 and
+ * 90 at +h/6) and they are two DIFFERENT lines; folding both into a half-turn
+ * range is what keeps them apart, and what stops a residual fold being
+ * stacked on top of a live one that is already there.
+ */
+function canonicalLine(angle: number, offset: number): [number, number] {
+  let a = ((angle % 360) + 360) % 360
+  let o = offset
+  if (a >= 180) {
+    a -= 180
+    o = -o
+  }
+  return [a, o]
+}
+
+/** Whether two folds/creases describe the same physical line on the sheet. */
+export function sameLine(
+  a: { angle: number; offset: number },
+  b: { angle: number; offset: number },
+): boolean {
+  const [aa, ao] = canonicalLine(a.angle, a.offset)
+  const [ba, bo] = canonicalLine(b.angle, b.offset)
+  // Near 0/180 the canonical angle wraps, so compare the way an angle has to be.
+  const d = Math.abs(aa - ba)
+  const angleClose = Math.min(d, 180 - d) <= CREASE_DRIFT_ANGLE
+  return angleClose && Math.abs(ao - bo) <= CREASE_DRIFT
+}
+
+/**
+ * Fold a sheet's remembered creases into the stack that is about to run.
+ *
+ * A crease is a FLOOR on the fold at its line, never an addition. Where the
+ * behavior is already folding that line further, the crease is invisible and
+ * contributes nothing; as the behavior lets go, the fold angle falls to the
+ * crease's depth and stops there. That is what makes the crease appear on
+ * the way back out of a fold without anything having to detect the release —
+ * and it is why the residual is written INTO the live instance rather than
+ * added beside it. Two folds on one line would not be a deeper crease, they
+ * would be two creases a hair apart, and `fold` does not commute.
+ *
+ * Creases with no live fold on their line are prepended: a sheet that is
+ * already creased is creased BEFORE the behavior gets hold of it, so the
+ * behavior bends a creased sheet rather than the crease bending a bent one.
+ */
+export function applyMemory(stack: DeformerInstance[], creases: CreaseConfig[]): DeformerInstance[] {
+  if (creases.length === 0) return stack
+
+  let out = stack
+  const loose: CreaseConfig[] = []
+
+  for (const crease of creases) {
+    if (Math.abs(crease.depth) < MIN_DEPTH) continue
+    const index = out.findIndex(
+      (i) => i.type === 'fold' && i.enabled !== false && sameLine(i.options as FoldOptions, crease),
+    )
+    if (index === -1) {
+      loose.push(crease)
+      continue
+    }
+    const live = out[index]!
+    const options = live.options as FoldOptions
+    if (Math.abs(options.foldAngle) >= Math.abs(crease.depth)) continue
+    // Copy on first write — the stack a behavior returns is not ours to edit,
+    // and on a resting sheet it is the same array every frame.
+    if (out === stack) out = [...stack]
+    out[index] = { ...live, options: { ...options, foldAngle: crease.depth } }
+  }
+
+  if (loose.length === 0) return out
+  return [...loose.map(toFold), ...out]
+}
+
+/** A remembered crease as the deformer that draws it. */
+function toFold(crease: CreaseConfig): DeformerInstance {
+  return {
+    type: 'fold',
+    options: {
+      angle: crease.angle,
+      offset: crease.offset,
+      foldAngle: crease.depth,
+      radius: CREASE_RADIUS,
+    } satisfies FoldOptions,
+  }
+}
+
+interface Slot {
+  angle: number
+  offset: number
+  /** The most OPEN this line has been — every closing is measured from here. */
+  trough: number
+  /** The largest closing it has made from a trough. */
+  bestGrowth: number
+  /** How far shut it was at the top of that closing — the crease's own angle. */
+  bestPeak: number
+  /** Which way it was folded, so the crease opens back the way it came. */
+  sign: number
+}
+
+/**
+ * Watches a running deformer stack and records the creases it leaves.
+ *
+ * One per sheet, driven from the frame loop. It is deliberately not a
+ * reducer over config: recording has to happen at frame rate to catch the
+ * peak of a fold, and routing sixty writes a second through React would cost
+ * more than the whole rest of the feature. Instead this holds the live truth
+ * and says when it has changed, and the host persists that at its own pace —
+ * the same split `onBehaviorChange` already uses for handle drags.
+ *
+ * Slots are keyed by POSITION in the stack, which is the only stable identity
+ * a fold has: a behavior's stack is a pure function of its options, so
+ * `stack[1]` is the same fold from frame to frame, while its angle and offset
+ * are exactly the things that may legitimately move.
+ */
+export class CreaseTracker {
+  private slots = new Map<number, Slot>()
+  private recorded: CreaseConfig[] = []
+  private authored: CreaseConfig[] = []
+
+  constructor(authored: CreaseConfig[] = []) {
+    this.authored = authored
+  }
+
+  /**
+   * Forget how the paper got here without forgetting the creases.
+   *
+   * Called when the stack is replaced wholesale (a new behavior, a new
+   * sheet): the slots describe folds that no longer exist, but a crease is a
+   * property of the paper and survives being put down and picked up.
+   */
+  reset(authored: CreaseConfig[] = this.creases): void {
+    this.slots.clear()
+    this.recorded = []
+    this.authored = authored
+  }
+
+  /**
+   * Take on a crease set that came from outside — a config edit, a shared
+   * link, or this tracker's own recording after the host has persisted it.
+   *
+   * Slots are deliberately left alone. They describe the folds currently
+   * running, which is a different question from what the paper carries, and
+   * clearing them here would stall a crease mid-fold: the host writes back
+   * the moment a crease appears, and if that write reset the peak, the rest
+   * of the same fold would count as growth from a base it had already passed.
+   */
+  adopt(creases: CreaseConfig[]): void {
+    this.authored = creases
+    this.recorded = []
+  }
+
+  /** Everything the sheet currently carries, authored and recorded merged. */
+  get creases(): CreaseConfig[] {
+    return merge(this.authored, this.recorded)
+  }
+
+  /**
+   * Take one frame's reading. Returns true when the crease set changed by
+   * enough to be worth telling anyone about.
+   */
+  observe(stack: DeformerInstance[], set: number): boolean {
+    if (set <= 0) return false
+
+    for (let i = 0; i < stack.length; i++) {
+      const instance = stack[i]!
+      if (instance.type !== 'fold' || instance.enabled === false) continue
+      const o = instance.options as FoldOptions
+      const magnitude = Math.abs(o.foldAngle)
+      const slot = this.slots.get(i)
+
+      // A fold we have not seen, or one whose line has travelled out from
+      // under itself. Either way the paper it is bending now is not the paper
+      // it was bending, so counting starts again from where it is.
+      //
+      // The comparison is against where the line SETTLED, never against last
+      // frame — absorbing drift a frame at a time would let a slowly
+      // travelling hinge creep the length of the sheet without ever tripping
+      // the tolerance it exists to trip.
+      if (
+        !slot ||
+        Math.abs(slot.angle - o.angle) > CREASE_DRIFT_ANGLE ||
+        Math.abs(slot.offset - o.offset) > CREASE_DRIFT
+      ) {
+        this.slots.set(i, {
+          angle: o.angle,
+          offset: o.offset,
+          trough: magnitude,
+          bestGrowth: 0,
+          bestPeak: magnitude,
+          sign: o.foldAngle < 0 ? -1 : 1,
+        })
+        continue
+      }
+
+      // The crease is the biggest CLOSING this line has made, measured from
+      // however open it last was — not from wherever we happened to start
+      // watching. A letter that arrives folded and is opened has closed
+      // nothing, and creases nothing; open it and fold it again and the same
+      // line has now made the whole travel, and creases. Both readings fall
+      // out of a running minimum and nothing else.
+      if (magnitude < slot.trough) slot.trough = magnitude
+      const growth = magnitude - slot.trough
+      if (growth > slot.bestGrowth) {
+        slot.bestGrowth = growth
+        slot.bestPeak = magnitude
+        slot.sign = o.foldAngle < 0 ? -1 : 1
+      }
+    }
+
+    const next: CreaseConfig[] = []
+    for (const slot of this.slots.values()) {
+      if (slot.bestGrowth < CREASE_MIN_GROWTH) continue
+      const depth = slot.sign * slot.bestPeak * set * MAX_SET
+      if (Math.abs(depth) < MIN_DEPTH) continue
+      next.push({ angle: slot.angle, offset: slot.offset, depth })
+    }
+
+    if (same(next, this.recorded)) return false
+    this.recorded = next
+    return true
+  }
+}
+
+/**
+ * Merge two crease sets, deepest wins per line, capped at what the shader
+ * carries.
+ *
+ * Recorded creases meet authored ones on the same line whenever a preset
+ * ships pre-creased and then gets folded along its own crease — and the
+ * answer there is the deeper of the two, not their sum: folding a creased
+ * sheet along its crease does not double the crease, it just re-makes it.
+ */
+function merge(authored: CreaseConfig[], recorded: CreaseConfig[]): CreaseConfig[] {
+  const out: CreaseConfig[] = []
+  for (const crease of [...recorded, ...authored]) {
+    const existing = out.find((c) => sameLine(c, crease))
+    if (!existing) {
+      out.push(crease)
+      continue
+    }
+    if (Math.abs(crease.depth) > Math.abs(existing.depth)) existing.depth = crease.depth
+  }
+  // Over the cap, the deepest creases are the ones anyone would miss.
+  if (out.length > MAX_CREASES) {
+    out.sort((a, b) => Math.abs(b.depth) - Math.abs(a.depth))
+    out.length = MAX_CREASES
+  }
+  return out
+}
+
+/** Whether two crease sets are the same to within a degree of depth. */
+function same(a: CreaseConfig[], b: CreaseConfig[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((crease, i) => {
+    const other = b[i]!
+    return sameLine(crease, other) && Math.abs(crease.depth - other.depth) < 0.5
+  })
+}

--- a/packages/paperlab/src/deformers/memory.ts
+++ b/packages/paperlab/src/deformers/memory.ts
@@ -197,6 +197,8 @@ export class CreaseTracker {
   private slots = new Map<number, Slot>()
   private recorded: CreaseConfig[] = []
   private authored: CreaseConfig[] = []
+  /** What `observe` last handed out, so an echo can be told from an edit. */
+  private lastReported: CreaseConfig[] = []
 
   constructor(authored: CreaseConfig[] = []) {
     this.authored = authored
@@ -216,16 +218,31 @@ export class CreaseTracker {
   }
 
   /**
-   * Take on a crease set that came from outside — a config edit, a shared
-   * link, or this tracker's own recording after the host has persisted it.
+   * Take on a crease set that came from outside, and work out which kind of
+   * outside it was — because the two kinds want opposite things.
    *
-   * Slots are deliberately left alone. They describe the folds currently
-   * running, which is a different question from what the paper carries, and
-   * clearing them here would stall a crease mid-fold: the host writes back
-   * the moment a crease appears, and if that write reset the peak, the rest
-   * of the same fold would count as growth from a base it had already passed.
+   * It is USUALLY this tracker's own recording coming back, a frame or two
+   * after `onCrease` handed it to the host. Then the slots must survive: the
+   * fold that made the crease is very likely still closing, and resetting
+   * its peak on the host's echo would stall the crease halfway into the
+   * fold that was making it.
+   *
+   * But it can also be somebody EDITING the paper — a depth dragged down in
+   * a panel, a shared link opened, a state's overrides settling. Then the
+   * slots are the wrong story to keep. `merge` takes the deeper of two
+   * creases on a line, so a recording of 20° would quietly outvote a human
+   * asking for 5° and the slider would appear not to work; and it would go
+   * on outvoting it, because the fold that recorded the 20 is still sitting
+   * in a slot. An edit means the paper is what it is now, and the next
+   * crease has to be earned by folding it again.
+   *
+   * The two are told apart by what we last reported. Anything else is an
+   * edit, which is the safe way round: mistaking an echo for an edit costs
+   * a crease that gets re-recorded on the next fold, while mistaking an edit
+   * for an echo costs a control that does not work.
    */
   adopt(creases: CreaseConfig[]): void {
+    if (!same(creases, this.lastReported)) this.slots.clear()
     this.authored = creases
     this.recorded = []
   }
@@ -298,6 +315,7 @@ export class CreaseTracker {
 
     if (same(next, this.recorded)) return false
     this.recorded = next
+    this.lastReported = this.creases
     return true
   }
 }

--- a/packages/paperlab/src/index.ts
+++ b/packages/paperlab/src/index.ts
@@ -50,6 +50,8 @@ export {
   contentNames,
   contentSchemaFor,
   washSchema,
+  creaseSchema,
+  memorySchema,
   paperEdges,
   coreStateNames,
   type PaperConfig,
@@ -66,6 +68,10 @@ export {
   type DeformerInstanceConfigInput,
   type SurfaceConfig,
   type SurfaceConfigInput,
+  type CreaseConfig,
+  type CreaseConfigInput,
+  type MemoryConfig,
+  type MemoryConfigInput,
   type PaperEdge,
   type PhysicsConfig,
   type PhysicsConfigInput,
@@ -127,6 +133,16 @@ export { idleNames, type IdleName, type IdlePreset } from './physics/idle'
  * and the roll comes apart, so a length control needs to know where to stop.
  */
 export { maxStripLength } from './physics/strip'
+
+/**
+ * Paper memory — creasing, and what a sheet keeps of a fold.
+ *
+ * `applyMemory` is exported because it is the one piece a host might need to
+ * reproduce outside the frame loop: an exporter or a thumbnailer that builds
+ * a stack by hand has to fold the creases in the same way, or a shared link
+ * renders one shape in the editor and another in the picture of it.
+ */
+export { applyMemory, CreaseTracker, MAX_SET, MAX_CREASES } from './deformers/memory'
 
 // ── Lighting is data, not an enum ───────────────────────────────────────────
 

--- a/packages/paperlab/src/surface/PaperMaterial.tsx
+++ b/packages/paperlab/src/surface/PaperMaterial.tsx
@@ -4,6 +4,7 @@ import CustomShaderMaterial from 'three-custom-shader-material'
 import type { LightingName, SurfaceConfig } from '../config/schema'
 import type { Stock } from '../core/stock'
 import { composeSurface } from './compose'
+import { resolveCreases, type CreaseShading } from './creases'
 import { useLightRig } from '../scene/rig'
 
 export interface PaperMaterialProps {
@@ -21,6 +22,12 @@ export interface PaperMaterialProps {
    * lit by the hall, not by the preset it was authored with.
    */
   lighting?: LightingName
+  /**
+   * Crease lines to draw, resolved from `surface.creaseLines` plus whatever
+   * the sheet remembers being folded along. Left off, only the authored ones
+   * render — which is what a material with no memory behind it should do.
+   */
+  creases?: CreaseShading[]
 }
 
 /**
@@ -38,6 +45,7 @@ export function PaperMaterial({
   thickness,
   sheet,
   lighting = 'studio',
+  creases,
 }: PaperMaterialProps) {
   const rig = useLightRig(lighting)
   const composed = composeSurface(
@@ -50,6 +58,7 @@ export function PaperMaterial({
     },
     sheet,
     rig,
+    creases ?? resolveCreases(surface, [], sheet ?? { width: 1, height: 1.4 }),
   )
 
   // Uniform objects bound to the current program; stable per structure.

--- a/packages/paperlab/src/surface/compose.ts
+++ b/packages/paperlab/src/surface/compose.ts
@@ -6,6 +6,7 @@ import {
   type SurfaceConfig,
 } from '../config/schema'
 import type { Stock } from '../core/stock'
+import { resolveCreases, type CreaseShading } from './creases'
 import type { LightingPreset } from '../scene/lighting'
 import {
   TRANSLUCENCY_FRAGMENT,
@@ -128,23 +129,29 @@ void plDeckle(inout vec4 color) {
 `
 
 const CREASE_CHUNK = /* glsl */ `
-uniform float uCreaseAngle;
-uniform float uCreaseStrength;
+uniform float uCreaseAngles[4];
+uniform float uCreaseStrengths[4];
 uniform float uCreasePositions[4];
 uniform int uCreaseCount;
 
 void plCrease(inout vec4 color, inout float rough) {
-  vec2 dir = vec2(cos(uCreaseAngle), sin(uCreaseAngle));
-  // Coordinate across the crease lines (0..1 over the sheet).
-  float t = dot(vPaperUv - 0.5, vec2(-dir.y, dir.x)) + 0.5;
   for (int i = 0; i < 4; i++) {
     if (i >= uCreaseCount) break;
+    // Per crease rather than once for the set: a remembered crease is placed
+    // by the fold that made it, and a sheet folded twice was not necessarily
+    // folded twice the same way. A map creased both directions has to draw
+    // both, and the trig is four cosines on a shader that only runs at all
+    // when the sheet has creases.
+    vec2 dir = vec2(cos(uCreaseAngles[i]), sin(uCreaseAngles[i]));
+    // Coordinate across this crease line (0..1 over the sheet).
+    float t = dot(vPaperUv - 0.5, vec2(-dir.y, dir.x)) + 0.5;
+    float strength = uCreaseStrengths[i];
     float d = abs(t - uCreasePositions[i]);
     float shadow = smoothstep(0.014, 0.0, d);
     float sheen = smoothstep(0.02, 0.006, d) - smoothstep(0.006, 0.0, d);
-    color.rgb *= 1.0 - shadow * uCreaseStrength * 0.28;
-    color.rgb += sheen * uCreaseStrength * 0.05;
-    rough = clamp(rough + shadow * uCreaseStrength * 0.2, 0.0, 1.0);
+    color.rgb *= 1.0 - shadow * strength * 0.28;
+    color.rgb += sheen * strength * 0.05;
+    rough = clamp(rough + shadow * strength * 0.2, 0.0, 1.0);
   }
 }
 `
@@ -219,11 +226,17 @@ export function composeSurface(
   sheet: { width: number; height: number } = { width: 1, height: 1.4 },
   /** Whose key light transmission is measured against — a preset name or the scene's resolved rig. */
   lighting: LightingName | LightingPreset = 'studio',
+  /**
+   * The crease lines to draw, already resolved. Authored `surface.creaseLines`
+   * and the sheet's remembered creases both arrive here as the same thing —
+   * see `resolveCreases`, which is the only place that knows they came from
+   * two different questions.
+   */
+  creases: CreaseShading[] = resolveCreases(surface, [], sheet),
 ): ComposedSurface {
   const grain = surface.grain ?? stock.defaultSurface.grain
   const aging = surface.aging ?? stock.defaultSurface.aging
   const deckle = surface.deckle
-  const creases = surface.creaseLines
   const perforation = surface.perforation
   const banding = stock.banding
   // Adhesive undersides are opaque backing-paper white — nothing shows through.
@@ -273,13 +286,18 @@ export function composeSurface(
     uniforms.uPerfSpacing = { value: perforation.spacing }
     uniforms.uSheetSize = { value: new THREE.Vector2(sheet.width, sheet.height) }
   }
-  if (creases) {
+  if (creases.length > 0) {
     chunks.push(CREASE_CHUNK)
     calls.push('plCrease(csm_DiffuseColor, csm_Roughness);')
-    uniforms.uCreaseAngle = { value: (creases.angle * Math.PI) / 180 }
-    uniforms.uCreaseStrength = { value: creases.strength }
-    uniforms.uCreasePositions = { value: padPositions(creases.positions) }
-    uniforms.uCreaseCount = { value: Math.min(creases.positions.length, 4) }
+    uniforms.uCreaseAngles = { value: pad(creases.map((c) => (c.angle * Math.PI) / 180)) }
+    uniforms.uCreaseStrengths = { value: pad(creases.map((c) => c.strength)) }
+    uniforms.uCreasePositions = {
+      value: pad(
+        creases.map((c) => c.position),
+        -1,
+      ),
+    }
+    uniforms.uCreaseCount = { value: Math.min(creases.length, 4) }
   }
   if (aging !== undefined) {
     chunks.push(AGING_CHUNK)
@@ -325,7 +343,7 @@ void main() {
     structureKey: `${[
       grain !== undefined || banding > 0 ? 'g' : '',
       deckle ? 'd' : '',
-      creases ? 'c' : '',
+      creases.length > 0 ? 'c' : '',
       aging !== undefined ? 'a' : '',
       perforation ? 'p' : '',
       stock.adhesive ? 'A' : '',
@@ -337,8 +355,8 @@ void main() {
   }
 }
 
-function padPositions(positions: number[]): number[] {
-  const out = positions.slice(0, 4)
-  while (out.length < 4) out.push(-1)
+function pad(values: number[], fill = 0): number[] {
+  const out = values.slice(0, 4)
+  while (out.length < 4) out.push(fill)
   return out
 }

--- a/packages/paperlab/src/surface/creases.ts
+++ b/packages/paperlab/src/surface/creases.ts
@@ -1,0 +1,80 @@
+import type { CreaseConfig, SurfaceConfig } from '../config/schema'
+import { spanAlong } from '../core/tessellation'
+import { MAX_SET } from '../deformers/memory'
+
+/** How many crease lines the shader carries. */
+const MAX_SHADED = 4
+
+/** One crease in the terms the crease shader wants. */
+export interface CreaseShading {
+  /** Direction of the crease LINE, degrees. */
+  angle: number
+  /** Where the line sits across the sheet, 0..1. */
+  position: number
+  /** How hard it reads, 0..1. */
+  strength: number
+}
+
+/**
+ * Everything that should draw as a crease line, from the two places creases
+ * come from.
+ *
+ * `surface.creaseLines` is authored SHADING: a designer saying "put fold
+ * marks here", with no geometry behind it. `memory.creases` is what the paper
+ * has actually been folded along, and it bends the sheet as well as marking
+ * it. They coexist because they answer different questions, and the authored
+ * ones come first so that a hand-placed mark is never the one dropped at the
+ * cap.
+ */
+export function resolveCreases(
+  surface: SurfaceConfig,
+  creases: CreaseConfig[],
+  sheet: { width: number; height: number },
+): CreaseShading[] {
+  const out: CreaseShading[] = []
+
+  const lines = surface.creaseLines
+  if (lines) {
+    for (const position of lines.positions) {
+      out.push({ angle: lines.angle, position, strength: lines.strength })
+    }
+  }
+
+  for (const crease of creases) {
+    out.push(creaseShading(crease, sheet))
+  }
+
+  if (out.length > MAX_SHADED) out.length = MAX_SHADED
+  return out
+}
+
+/**
+ * A remembered crease as the fragment shader draws it.
+ *
+ * Two conversions, and both are places the geometry and the shading could
+ * silently disagree. `fold.angle` is the direction the fold TRAVELS and the
+ * crease line runs across it, while the shader's angle IS the line — hence
+ * the 90. And `fold.offset` is a signed world distance from the centre while
+ * the shader works in 0..1 across the sheet, hence the span.
+ *
+ * The span conversion is exact for a crease square to an edge, which is every
+ * crease any built-in behavior makes, and approximate for a diagonal one —
+ * the shader measures in UV, where the sheet's own aspect has already been
+ * divided out. That is a property of the crease effect as it has always been
+ * (`creaseLines.positions` are UV fractions too), not something memory
+ * introduces.
+ */
+export function creaseShading(crease: CreaseConfig, sheet: { width: number; height: number }): CreaseShading {
+  const span = spanAlong(sheet, crease.angle)
+  return {
+    angle: crease.angle - 90,
+    position: span > 0 ? 0.5 + crease.offset / span : 0.5,
+    // A crease reads hardest around a right angle and then saturates: a sheet
+    // folded flat and reopened is not four times the mark of one folded to
+    // 45°, it is a slightly harder version of the same line. The divisor is
+    // the depth a 90° fold leaves in paper that remembers everything — read
+    // off `MAX_SET` rather than written out, so retuning how much paper keeps
+    // cannot leave the shading calibrated against the old answer.
+    strength: Math.min(1, Math.abs(crease.depth) / (90 * MAX_SET)),
+  }
+}


### PR DESCRIPTION
Paper is plastic where cloth is elastic. Every deformer in the library is a pure function of its options, so a sheet folded to 180° and back to 0° came out of the stack pristine — correct for cloth, and wrong for the one material Paperlab models. This is the layer that remembers.

## Where it lives

**Above the deformer stack, never inside it.** Deformer purity is what the GLSL twins are identical *to*, what lets the field scale one instance's bend by a per-sheet bias, and what `test:parity` checks. So `deformers/memory.ts` watches the stack a behavior built and rewrites it before it runs. No deformer knows memory exists, and parity is untouched (37/37).

## The rule that makes it work

A crease is recorded where a fold **closes at a line that stays put**, measured from however open that line last was.

That rule is doing real work, because `fold` is used for two different things. `unroll`'s landing hinge is a fold instance that sits at exactly 90° forever while its line walks down the sheet — a fixed floor is a moving line in sheet coordinates. Paper coming off a roll is *bent* at the floor, not creased along it, and a trail of creases behind it would be the obvious bug. Measuring the closing rather than the angle gets both right without asking any behavior to declare anything about its own folds.

Applied, a crease is a **floor on the fold at its line, never an addition**. While the behavior folds past it the crease is invisible; as the fold lets go the angle falls to the crease's depth and stops. That is what makes a crease appear on the way *out* of a fold with nothing detecting the release — and why the residual is written into the live instance rather than added beside it (two folds on one line are two creases a hair apart, and `fold` does not commute).

## What's in it

- `memory: { set?, creases: [{ angle, offset, depth }] }` on the schema, and `memory` as a `<Paper>` prop. Creases name their line in `fold`'s own terms, which is what lets a remembered crease and a live fold recognise each other.
- `Stock.takesSet` — kraft 0.85 holds a crease hard, vellum 0.25 springs back.
- `onCrease` for persistence, on the same split `onBehaviorChange` already uses: the mesh holds the live truth at frame rate, the host writes it back at its own pace.
- Per-crease **angle and strength** in the crease shader, so a sheet creased both ways draws both instead of only the dominant direction.
- A **Memory panel** in the editor — creases are draggable, removable, and authorable by hand.
- Docs section, README, AGENTS.md.

## Two things it caught on the way

**`diffConfig` dropped it.** The preset round-trip test failed the moment a preset carried creases — which means the editor would have shown creases that nothing leaving the editor carried, in a `.paper` file, a share link or a snippet. Exactly the bug the `scene` diff already has a comment about. Fixed, and pinned by its own test.

**`memory` wasn't a prop.** I added the schema field and wired the whole pipeline before noticing `<Paper memory={...}>` didn't type-check. `config/props.test.ts` exists because `surface` was documented as a prop for a while without being one; `memory` is now in both halves of it.

## Behaviour change

**On by default**, at the stock's own setting — paper that forgets is the bug this fixes, so remembering shouldn't be something a preset has to ask for. `memory={{ set: 0 }}` is the opt-out and is exactly how every sheet behaved before this.

The blast radius is one built-in: `letter-fold`. It shipped two painted-on `surface.creaseLines` — a good impression of a crease right up until you unfold the letter and it comes back flat. It now ships the creases themselves, so they bend the sheet as well as marking it, and folding the letter deepens the creases it already has rather than drawing a second pair on top of them.

## Verification

`pnpm test` (37 new tests), `typecheck`, `lint`, `knip` clean. All five CI gates pass: `test:parity` 37/37, `test:share` 10/10, `test:drive`, `test:dropdown` 30/30, `test:route` 10/10. `pnpm perf` is flat against `main` (158.4ms vs 160.0ms high, 61.2 vs 61.2 medium) — a resting sheet returns before memory does anything.

Shot the fold cycle headless to confirm: flat → folded → **and the reopened letter is no longer flat**.

## Scoped out, deliberately

Residual **curl** (roll → unroll leaves a curl) and residual **crumple** are the same idea on different deformer families, and each needs its own config field. `memory` is shaped to take them as siblings. Shipping creases complete beat shipping three half-features.

Field mode stays elastic — a crease is per-sheet state and the field is one instanced draw call, so it would need per-instance attributes that don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paper now remembers folds and preserves creases based on material characteristics.
  * Configure crease retention, add or remove creases, flatten remembered folds, and receive crease updates in the editor.
  * Remembered creases can be serialized in presets and shared configurations.
  * Letter-fold presets now include persistent crease geometry.
* **Documentation**
  * Added a Memory guide with interactive examples and usage details.
* **Bug Fixes**
  * Improved crease rendering for multiple independent crease lines and pre-folded sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->