### PR TITLE
feat(site): the hands page is a route people can actually reach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,14 +560,22 @@ pnpm knip           # dead code and unused exports
 | `pnpm test:share` | the editor | sculpt → copy a link → open it in a browser that has never seen the paper. **CI gate** |
 | `pnpm test:dropdown` | the editor | every option list is reachable — including the ones below the fold. **CI gate** |
 | `pnpm test:hands` | `/hands` | scripted gestures really reach the paper — grab, score, paint, tear, crush, blow, pointer capture, and that the page talks to nobody. Runs `pnpm hands:setup` for you |
-| `pnpm test:route` | `tools/site-root.html` | the site root sends desktops to the editor and everything else to the playground. **CI gate** |
+| `pnpm test:route` | `tools/site-root.html` | the site root sends desktops to the editor and everything else to the playground, and its nav names every route `pages.yml` deploys. **CI gate** |
 | `pnpm perf` / `perf:field` | `stage.html` / `field.html` | frame cost. `--gpu` for the platform GPU, `--soft` for the SwiftShader floor |
 | `pnpm shot` / `shot:ui` / `shot:play` / `shot:light` | stage, editor, playground, one rig | PNGs into `.shots/` |
 | `pnpm media` | `media.html` | the README's GIFs and MP4s, stepped frame-exact |
 
-**`/hands` is a real page on the site, and `pnpm hands:setup` before it will
-start.** The tracker's wasm is served from our own origin — it is executable
-code in a page holding a camera stream, and as `@mediapipe/tasks-vision` it is
+**`/hands` is a real page on the site, and it is linked like one.** The
+signpost at the root names it, and so does the reference's rail — it shipped
+without either for its first weeks, deployed and unreachable, which is why
+`pnpm test:route` now reads the routes out of `pages.yml` and fails if the
+signpost does not name one. It is never a redirect TARGET: it wants a camera
+and two model files before it does anything, so it is somewhere you choose to
+go, not somewhere you are sent.
+
+**Run `pnpm hands:setup` before the page will start.** The tracker's wasm is
+served from our own origin — it is executable code in a page holding a camera
+stream, and as `@mediapipe/tasks-vision` it is
 Apache-2.0, so there is no question about hosting it. `tools/hands-assets.mjs`
 copies it out of `node_modules` (already a declared dependency, so the same
 bytes at the same version) into `apps/editor/.hands/`, which is gitignored:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A hero image that peels, a receipt that unrolls, a letter that folds, a poster rippling in wind, a gallery ring of prints. A sheet is real 3D geometry, not a CSS trick and not a video — content is a texture on a mesh that genuinely bends, so text and imagery curl with perfect continuity.
 
-**[Try it →](https://paperlab.nawwara.studio/)**  ·  [the editor](https://paperlab.nawwara.studio/editor/) (desktop)  ·  [the reference](https://paperlab.nawwara.studio/docs/)  ·  [for coding agents](AGENTS.md)
+**[Try it →](https://paperlab.nawwara.studio/)**  ·  [the editor](https://paperlab.nawwara.studio/editor/) (desktop)  ·  [the reference](https://paperlab.nawwara.studio/docs/)  ·  [with your hands](https://paperlab.nawwara.studio/hands/) (webcam)  ·  [for coding agents](AGENTS.md)
 
 | | |
 |---|---|
@@ -189,7 +189,7 @@ That's the whole loop: **make → send → remix → ship.** If you'd rather you
 
 ## The apps
 
-Three surfaces ship alongside the library, all built on its public API only.
+Four surfaces ship alongside the library, all built on its public API only.
 
 **[The playground](https://paperlab.nawwara.studio/playground/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
 
@@ -205,6 +205,10 @@ Field mode composes galleries against the same panel — swap the layout, watch 
 
 **[The reference](https://paperlab.nawwara.studio/docs/)** — the whole catalogue with every behavior, deformer, layout, stock and surface rendering live. The catalogue is generated from the registries, so it cannot advertise something the library doesn't have.
 
+**[Your hands](https://paperlab.nawwara.studio/hands/)** — the same paper, driven by a webcam instead of a mouse. Pinch to take hold and pull, point to score a line, make a fist to fold along it, turn your palm to change the stock, flick paint at it, blow at it to raise the wind, pull an edge to tear it. Every gesture lands on a feature the library already ships — the page is a hundred percent public API, and `packages/paperlab` doesn't know it exists.
+
+The tracking is [MediaPipe](https://ai.google.dev/edge/mediapipe) (`@mediapipe/tasks-vision`, Apache-2.0) and it runs entirely in your browser: the models download from Google once, and after that no video and no measurement taken from it leaves the device. There is no server to send it to, and a `connect-src` CSP on the page makes that enforceable rather than a promise — including against MediaPipe's own usage telemetry, which the page blocks. Needs a camera, and asks before it takes one.
+
 ## Development
 
 pnpm + Turborepo, Node 22, [Biome](https://biomejs.dev) for lint and format.
@@ -217,7 +221,7 @@ pnpm dev            # the editor at localhost:5173
 | | |
 |---|---|
 | [`packages/paperlab`](packages/paperlab/) | the npm library — the only published artifact |
-| [`apps/editor`](apps/editor/) | the editor — every knob, and the export |
+| [`apps/editor`](apps/editor/) | the editor — every knob, and the export. Also the `/hands` page, built from the same app in a second pass |
 | [`apps/playground`](apps/playground/) | the playground — one input, one scene, shareable by link |
 | [`apps/docs`](apps/docs/) | the reference site, with every behavior running live |
 | [`tools/`](tools/) | browser harnesses — parity, perf, screenshots, the README's motion |
@@ -232,14 +236,15 @@ pnpm test:parity    # 37 golden-vector cases: every deformer's GLSL twin vs its 
 pnpm test:drive     # the stage really walks when you drag, wheel or arrow it
 pnpm test:share     # sculpt → link → a browser that has never seen the paper
 pnpm test:dropdown  # every dropdown option is reachable, including below the fold
-pnpm test:route     # the site root sends each device to the app built for it
+pnpm test:route     # the site root routes by device, and links every route it deploys
+pnpm test:hands     # scripted gestures really reach the paper (needs a camera-less Chromium)
 pnpm typecheck
 pnpm lint
 pnpm knip           # dead code and unused exports
 pnpm build
 ```
 
-Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All six test commands are CI gates, along with `publint` and `are-the-types-wrong` on the published package.
+Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All of them but `test:hands` are CI gates, along with `publint` and `are-the-types-wrong` on the published package — `test:hands` fetches its models from Google, so it is run by hand rather than made to speak for someone else's uptime.
 
 ### Measurement
 

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -48,6 +48,7 @@ export function App() {
         <div className="rail-links">
           <a href="../">Playground</a>
           <a href="../editor/">Editor</a>
+          <a href="../hands/">Hands</a>
           <a href="https://github.com/NourMtir0722/Paperlab">GitHub</a>
         </div>
       </nav>
@@ -142,6 +143,13 @@ export function Hero() {
         Every one of them is configured by the same zod schema, and any paper serializes to a{' '}
         <code>.paper</code> JSON object. That is the rule the project is built on: if a feature cannot
         serialize into a preset, it does not ship.
+      </p>
+
+      <p className="note">
+        Want to feel it rather than read it? <a href="../hands/">Handle the paper with your hands</a> — a
+        webcam drives a gesture vocabulary onto this same public API: pinch to take hold, point to score a
+        line, a fist to fold along it, blow at the sheet to raise the wind. It needs a camera and it asks
+        first; the video never leaves your machine.
       </p>
     </section>
   )

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -91,6 +91,27 @@ code {
   border-radius: 4px;
 }
 
+/*
+  The first links in the body copy. The rail had its own rule and the prose
+  had none, so an <a> here inherited the browser's blue — one hue past the
+  whole chroma budget, in the one app whose job is to look composed.
+
+  Hierarchy is a step, never a hue (see the ink ladder above), so a link is
+  simply the next step up out of the sentence it sits in, and the underline
+  is a hairline rather than a full-strength rule.
+*/
+main a {
+  color: var(--ink-2);
+  text-decoration: underline;
+  text-decoration-color: var(--hair-2);
+  text-underline-offset: 3px;
+}
+
+main a:hover {
+  color: var(--ink);
+  text-decoration-color: var(--ink-faint);
+}
+
 .app {
   display: grid;
   grid-template-columns: 216px minmax(0, 1fr);
@@ -180,27 +201,6 @@ code {
 main {
   padding: 56px 0 120px;
   min-width: 0;
-}
-
-/*
-  The first links in the body copy. The rail had its own rule and the prose
-  had none, so an <a> here inherited the browser's blue — one hue past the
-  whole chroma budget, in the one app whose job is to look composed.
-
-  Hierarchy is a step, never a hue (see the ink ladder above), so a link is
-  simply the next step up out of the sentence it sits in, and the underline
-  is a hairline rather than a full-strength rule.
-*/
-main a {
-  color: var(--ink-2);
-  text-decoration: underline;
-  text-decoration-color: var(--hair-2);
-  text-underline-offset: 3px;
-}
-
-main a:hover {
-  color: var(--ink);
-  text-decoration-color: var(--ink-faint);
 }
 
 section {

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -182,6 +182,27 @@ main {
   min-width: 0;
 }
 
+/*
+  The first links in the body copy. The rail had its own rule and the prose
+  had none, so an <a> here inherited the browser's blue — one hue past the
+  whole chroma budget, in the one app whose job is to look composed.
+
+  Hierarchy is a step, never a hue (see the ink ladder above), so a link is
+  simply the next step up out of the sentence it sits in, and the underline
+  is a hairline rather than a full-strength rule.
+*/
+main a {
+  color: var(--ink-2);
+  text-decoration: underline;
+  text-decoration-color: var(--hair-2);
+  text-underline-offset: 3px;
+}
+
+main a:hover {
+  color: var(--ink);
+  text-decoration-color: var(--ink-faint);
+}
+
 section {
   padding: 40px 0 64px;
   border-bottom: 1px solid var(--hair-2);

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -36,6 +36,7 @@ import { CoachMark, HandleAnchor, coachMarkUsed } from './chrome/CoachMark'
 import { CameraRig, ViewCluster } from './chrome/ViewCluster'
 import { CaptureRig, type CaptureHandle } from './chrome/CaptureRig'
 import { SmallScreen } from './chrome/SmallScreen'
+import { SITE } from './chrome/site'
 import { captureThumbnail, downloadPreset } from './state/userPresets'
 import { MAX_SHARE_LENGTH, SHARE_PARAM, paperShareUrl, readPaperShare } from './state/paperShare'
 import { DEMO_CARDS } from './state/demoAssets'
@@ -247,6 +248,32 @@ export function App() {
           </button>
         )}
         <div className="spacer" />
+        {/*
+          The one surface of this product the editor cannot show you.
+
+          /hands shipped as a real route and for weeks nothing pointed at it,
+          which made it a URL you had to already know. It is here rather than
+          in a menu because the whole problem was that nobody knew the feature
+          existed — a thing you have to open a dropdown to discover is a thing
+          you discover second.
+
+          A new tab on purpose: this is somewhere you go and come back from,
+          and the return trip through a cold three.js boot is worse than the
+          tab. The sculpt survives either way (see state/session.ts), so the
+          tab is for the reload, not for the work.
+        */}
+        <a
+          className="hands-link"
+          href={`${SITE}hands/`}
+          target="_blank"
+          rel="noopener"
+          title="Handle the paper with your webcam — pinch to take hold, point to score a line, blow at it to raise the wind"
+        >
+          Use your hands{' '}
+          <span className="hands-arrow" aria-hidden="true">
+            ↗
+          </span>
+        </a>
         {mode === 'paper' && (
           <button
             type="button"

--- a/apps/editor/src/chrome/SmallScreen.tsx
+++ b/apps/editor/src/chrome/SmallScreen.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { SITE } from './site'
 
 /**
  * What a phone gets instead of the editor.
@@ -34,9 +35,6 @@ import { useState } from 'react'
  * one, and rotating a tablet into landscape reveals the editor with no code
  * involved at all.
  */
-
-/** Sibling apps, from this one's base path — `/editor/` in production, `/` in dev. */
-const SITE = import.meta.env.BASE_URL.replace(/editor\/?$/, '')
 
 export function SmallScreen() {
   const [dismissed, setDismissed] = useState(false)

--- a/apps/editor/src/chrome/site.ts
+++ b/apps/editor/src/chrome/site.ts
@@ -1,0 +1,13 @@
+/**
+ * Where the sibling apps are, from wherever this one is mounted.
+ *
+ * The editor is served at `/editor/` in production and at `/` in dev, and the
+ * routes beside it — `/playground/`, `/docs/`, `/hands/` — are siblings of
+ * whichever it is. Deriving that from Vite's own base is what makes one href
+ * correct in both places without a build-time branch or an absolute URL that
+ * would break every local dev server and every preview deploy.
+ *
+ * It lives in its own file because two pieces of chrome now need it, and the
+ * regex is small enough that a second copy would look harmless and drift.
+ */
+export const SITE = import.meta.env.BASE_URL.replace(/editor\/?$/, '')

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -218,6 +218,40 @@ body {
   background: var(--hair-2);
 }
 
+/*
+  The way out to /hands.
+
+  A peer of Save preset and Share rather than a quieter outline, because it
+  is the only chrome in the app whose job is to tell you a feature exists —
+  and it deliberately does NOT invert to a white pill: rule 5 allows one per
+  screen and Export already is it. So it sits one luminance step below the
+  primary action and level with the document verbs, which is the honest
+  place for "there is another surface over here".
+
+  The arrow is the whole new-tab affordance; a second glyph would make it
+  the only iconed control in a text-only topbar.
+*/
+.hands-link {
+  background: var(--lift-2);
+  color: var(--ink);
+  border: 1px solid var(--hair-2);
+  border-radius: 6px;
+  padding: 6px 14px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.hands-link:hover {
+  background: var(--hair-2);
+}
+
+/* Its own class, not `.hands-link span`: a bare descendant selector here
+   lands between two rules further down the sheet and quietly voids their
+   noDescendingSpecificity suppression. */
+.hands-arrow {
+  color: var(--ink-body);
+}
+
 .preset-panel.dropping {
   outline: 2px dashed var(--ink-body);
   outline-offset: -4px;

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -8,7 +8,7 @@
 
 A hero image that peels, a receipt that unrolls, a letter that folds, a poster rippling in wind, a gallery ring of prints. A sheet is real 3D geometry, not a CSS trick and not a video — content is a texture on a mesh that genuinely bends, so text and imagery curl with perfect continuity.
 
-**[Try it →](https://paperlab.nawwara.studio/)**  ·  [the editor](https://paperlab.nawwara.studio/editor/) (desktop)  ·  [the reference](https://paperlab.nawwara.studio/docs/)  ·  [for coding agents](https://github.com/NourMtir0722/Paperlab/blob/main/AGENTS.md)
+**[Try it →](https://paperlab.nawwara.studio/)**  ·  [the editor](https://paperlab.nawwara.studio/editor/) (desktop)  ·  [the reference](https://paperlab.nawwara.studio/docs/)  ·  [with your hands](https://paperlab.nawwara.studio/hands/) (webcam)  ·  [for coding agents](https://github.com/NourMtir0722/Paperlab/blob/main/AGENTS.md)
 
 | | |
 |---|---|
@@ -189,7 +189,7 @@ That's the whole loop: **make → send → remix → ship.** If you'd rather you
 
 ## The apps
 
-Three surfaces ship alongside the library, all built on its public API only.
+Four surfaces ship alongside the library, all built on its public API only.
 
 **[The playground](https://paperlab.nawwara.studio/playground/)** — one input, one scene, shareable by link. Type a sentence and it builds you a room out of it. Built for a phone.
 
@@ -205,6 +205,10 @@ Field mode composes galleries against the same panel — swap the layout, watch 
 
 **[The reference](https://paperlab.nawwara.studio/docs/)** — the whole catalogue with every behavior, deformer, layout, stock and surface rendering live. The catalogue is generated from the registries, so it cannot advertise something the library doesn't have.
 
+**[Your hands](https://paperlab.nawwara.studio/hands/)** — the same paper, driven by a webcam instead of a mouse. Pinch to take hold and pull, point to score a line, make a fist to fold along it, turn your palm to change the stock, flick paint at it, blow at it to raise the wind, pull an edge to tear it. Every gesture lands on a feature the library already ships — the page is a hundred percent public API, and `packages/paperlab` doesn't know it exists.
+
+The tracking is [MediaPipe](https://ai.google.dev/edge/mediapipe) (`@mediapipe/tasks-vision`, Apache-2.0) and it runs entirely in your browser: the models download from Google once, and after that no video and no measurement taken from it leaves the device. There is no server to send it to, and a `connect-src` CSP on the page makes that enforceable rather than a promise — including against MediaPipe's own usage telemetry, which the page blocks. Needs a camera, and asks before it takes one.
+
 ## Development
 
 pnpm + Turborepo, Node 22, [Biome](https://biomejs.dev) for lint and format.
@@ -217,7 +221,7 @@ pnpm dev            # the editor at localhost:5173
 | | |
 |---|---|
 | [`packages/paperlab`](https://github.com/NourMtir0722/Paperlab/blob/main/packages/paperlab/) | the npm library — the only published artifact |
-| [`apps/editor`](https://github.com/NourMtir0722/Paperlab/blob/main/apps/editor/) | the editor — every knob, and the export |
+| [`apps/editor`](https://github.com/NourMtir0722/Paperlab/blob/main/apps/editor/) | the editor — every knob, and the export. Also the `/hands` page, built from the same app in a second pass |
 | [`apps/playground`](https://github.com/NourMtir0722/Paperlab/blob/main/apps/playground/) | the playground — one input, one scene, shareable by link |
 | [`apps/docs`](https://github.com/NourMtir0722/Paperlab/blob/main/apps/docs/) | the reference site, with every behavior running live |
 | [`tools/`](https://github.com/NourMtir0722/Paperlab/blob/main/tools/) | browser harnesses — parity, perf, screenshots, the README's motion |
@@ -232,14 +236,15 @@ pnpm test:parity    # 37 golden-vector cases: every deformer's GLSL twin vs its 
 pnpm test:drive     # the stage really walks when you drag, wheel or arrow it
 pnpm test:share     # sculpt → link → a browser that has never seen the paper
 pnpm test:dropdown  # every dropdown option is reachable, including below the fold
-pnpm test:route     # the site root sends each device to the app built for it
+pnpm test:route     # the site root routes by device, and links every route it deploys
+pnpm test:hands     # scripted gestures really reach the paper (needs a camera-less Chromium)
 pnpm typecheck
 pnpm lint
 pnpm knip           # dead code and unused exports
 pnpm build
 ```
 
-Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All six test commands are CI gates, along with `publint` and `are-the-types-wrong` on the published package.
+Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All of them but `test:hands` are CI gates, along with `publint` and `are-the-types-wrong` on the published package — `test:hands` fetches its models from Google, so it is run by hand rather than made to speak for someone else's uptime.
 
 ### Measurement
 

--- a/tools/route-check.mjs
+++ b/tools/route-check.mjs
@@ -99,10 +99,38 @@ console.log(failed ? `\n${failed} of ${cases.length} routes wrong` : `\nall ${ca
 // its own, which is what keeps it out of this.)
 const workflow = readFileSync(resolve(root, '.github/workflows/pages.yml'), 'utf8')
 const deployed = [...workflow.matchAll(/^\s*mkdir -p site\/(\S+)\s*$/gm)].map((m) => m[1])
-const linked = new Set([...html.matchAll(/<a href="\/([^"]*)"/g)].map((m) => m[1].replace(/\/$/, '')))
 
+/**
+ * The routes the signpost names — from the `<nav>` ONLY.
+ *
+ * Scanning the whole page would let any anchor anywhere satisfy this, and
+ * "there is an `<a>` somewhere in the file" is not the claim. The claim is
+ * that a visitor who lands on the root with the redirect not running sees a
+ * way to every route, and that is the nav or it is nothing.
+ *
+ * Returns null when there is no nav at all, which is its own failure.
+ */
+function navLinks(page) {
+  const nav = page.match(/<nav\b[^>]*>([\s\S]*?)<\/nav>/i)?.[1]
+  if (nav === undefined) return null
+  return new Set([...nav.matchAll(/<a href="\/([^"]*)"/g)].map((m) => m[1].replace(/\/$/, '')))
+}
+
+// The scoping above, asserted rather than trusted: a link outside the nav
+// must not count as a signpost.
+const decoy = navLinks('<a href="/hands/">not the nav</a><nav><a href="/editor/">e</a></nav>')
+if (decoy?.has('hands') !== false) {
+  console.error('\nthe link scan is not scoped to the <nav> — an anchor anywhere would satisfy it')
+  process.exit(1)
+}
+
+const linked = navLinks(html)
 if (deployed.length === 0) {
   console.error('\nno routes found in pages.yml — has the site assembly moved?')
+  process.exit(1)
+}
+if (linked === null) {
+  console.error('\nsite-root.html has no <nav> — nothing without JS can reach any route')
   process.exit(1)
 }
 

--- a/tools/route-check.mjs
+++ b/tools/route-check.mjs
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 /**
- * Checks the site root's device routing.
+ * Checks the site root — where it sends you, and what it lets you reach.
  *
  * The root is the URL everyone shares, and a script inside an HTML file is
  * the one bit of the site nothing else type-checks or renders — a typo there
  * sends every launch visitor to the wrong app, silently. So pull the script
  * out of the page and run the real thing against fake locations.
+ *
+ * Then the other direction: every route `pages.yml` deploys has to be named
+ * in the signpost's nav, because the redirect only knows about two of them
+ * and a route nothing links to is a route nobody has.
  *
  * Runs in CI as `pnpm test:route`.
  */
@@ -78,4 +82,40 @@ for (const [name, input, expected] of cases) {
 }
 
 console.log(failed ? `\n${failed} of ${cases.length} routes wrong` : `\nall ${cases.length} routes correct`)
+
+// ── Every deployed route is reachable from the signpost ────────────────────
+//
+// The redirect above is only half of what the root is for. The other half is
+// the nav, and it is the half that rots quietly: /hands shipped as a real
+// route — built, deployed, copied into site/hands by pages.yml — and for its
+// whole life nothing on the site linked to it. A page nobody can reach is a
+// page nobody has, and no test noticed, because every test was looking at
+// the redirect.
+//
+// So read the routes out of the WORKFLOW rather than restating them here. A
+// list written twice is a list that disagrees with itself; `mkdir -p site/x`
+// is the workflow saying "x is a route", and there is exactly one of those
+// per route. (`site/media` is images for the npm README and has no mkdir of
+// its own, which is what keeps it out of this.)
+const workflow = readFileSync(resolve(root, '.github/workflows/pages.yml'), 'utf8')
+const deployed = [...workflow.matchAll(/^\s*mkdir -p site\/(\S+)\s*$/gm)].map((m) => m[1])
+const linked = new Set([...html.matchAll(/<a href="\/([^"]*)"/g)].map((m) => m[1].replace(/\/$/, '')))
+
+if (deployed.length === 0) {
+  console.error('\nno routes found in pages.yml — has the site assembly moved?')
+  process.exit(1)
+}
+
+const unreachable = deployed.filter((route) => !linked.has(route))
+console.log(`\n${deployed.length} deployed routes: ${deployed.map((r) => `/${r}/`).join(' ')}`)
+if (unreachable.length) {
+  console.error(
+    `  FAIL deployed but nothing links to it: ${unreachable.map((r) => `/${r}/`).join(' ')}\n` +
+      '       add it to the <nav> in tools/site-root.html',
+  )
+  failed++
+} else {
+  console.log('  ok   every deployed route is named in the signpost')
+}
+
 process.exit(failed ? 1 : 0)

--- a/tools/site-root.html
+++ b/tools/site-root.html
@@ -14,7 +14,16 @@
       still reads the card below.
 
       Assembled into the site by .github/workflows/pages.yml. The apps
-      themselves live at /editor/, /playground/ and /docs/.
+      themselves live at /editor/, /playground/, /docs/ and /hands/.
+
+      /hands is never a redirect TARGET and never should be: it asks for a
+      camera and fetches two model files before it does anything, which is
+      not what an unsuspecting visitor to the root asked for. It is a place
+      you choose to go, so it is a link here and in the reference's rail —
+      and, because the redirect below fires before paint, the rail is the one
+      real people see. `pnpm test:route` asserts every route the workflow
+      deploys is named in the nav below, which is what this page missed: the
+      page shipped, and nothing on the site pointed at it.
     -->
     <meta property="og:url" content="https://paperlab.nawwara.studio/" />
     <meta property="og:type" content="website" />
@@ -118,6 +127,7 @@
         <a href="/editor/">The editor <span aria-hidden="true">→</span></a>
         <a href="/playground/">The playground <span aria-hidden="true">→</span></a>
         <a href="/docs/">The reference <span aria-hidden="true">→</span></a>
+        <a href="/hands/">Your hands <span aria-hidden="true">→</span></a>
       </nav>
     </main>
   </body>


### PR DESCRIPTION
`/hands` has been a real, deployed route for weeks — built in its own `PAPERLAB_HANDS=1` pass, copied into `site/hands` by `pages.yml`, gated by a CSP, covered by `pnpm test:hands`. Nothing on the site linked to it. The signpost named three apps, the reference's rail named two, and the README named neither, so the only way to the page was to already know the URL.

## What this does

Links it in the places that are load-bearing:

- **The reference's rail**, and a line in `Start` that says what it is. This is the one that matters — the signpost redirects before paint, so its `<nav>` is seen by crawlers and no-JS visitors and almost nobody else.
- **The signpost's nav**, for those two.
- **The README** — under the tagline, and as the fourth surface in *The apps*, with the MediaPipe/privacy story that the page's own copy already makes.

`/hands` is deliberately **not** a redirect target. It wants a camera and two model files before it does anything, so it is somewhere you choose to go, not somewhere you are sent.

## The guard

This is a class of bug, not an incident, so `pnpm test:route` now checks the other direction too: it reads the deployed routes out of `pages.yml` (`mkdir -p site/x` is the workflow saying *x is a route*, and there is exactly one per route) and fails if the signpost does not name one.

It fails on this commit's parent:

```
4 deployed routes: /playground/ /editor/ /hands/ /docs/
  FAIL deployed but nothing links to it: /hands/
       add it to the <nav> in tools/site-root.html
```

Reading the list out of the workflow rather than restating it here is the point — a list written twice is a list that disagrees with itself.

## Two things found on the way, fixed here

- **The docs stylesheet had no rule for a link in body copy**, only for the rail. The first prose link would have inherited the browser's blue — one hue past the whole chroma budget, in the app whose job is to look composed. `main a` is now a step up the ink ladder with a hairline underline, no new colour.
- **The README's checks list never mentioned `pnpm test:hands`** and claimed all six commands were CI gates. It is not one, and this PR does not make it one: it fetches its models from Google, and a gate that speaks for someone else's uptime blocks every PR when they have a bad afternoon. Now listed, and named as the exception. **Worth a decision either way — see below.**

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (54 docs tests incl. the design-system and drift tests), `pnpm knip`, `pnpm build` — all green
- `pnpm test:route` — 10 redirect cases + the new coverage assertion
- `pnpm test:hands` — green, 65s locally, camera live, models fetched, MediaPipe's telemetry endpoint blocked by the CSP as designed
- Rendered and eyeballed: the reference's rail and the new note, and the signpost fallback at 1440px and 390px (the fourth pill wraps to a clean 2×2)

## Open question

`test:hands` is the only browser harness that is not a CI gate, and `/hands` is now an official surface with nothing standing between a regression and the live site. Adding it costs ~5 min of CI and a dependency on `storage.googleapis.com` being up. I left it out; say the word and it goes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the “Your hands” webcam experience, allowing users to interact with the paper surface through gestures.
  - Added navigation links to the Hands experience from the site, documentation, and reference materials.
  - Updated app listings to reflect four available surfaces.

- **Documentation**
  - Added usage details, camera-permission requirements, and local-video privacy information for the Hands experience.
  - Documented route and Hands validation commands.

- **Bug Fixes**
  - Improved route checks to detect deployed pages that are not linked from the site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->