### PR TITLE
ci(hands): give the hands page a watchdog, not a veto

### DIFF
--- a/.github/workflows/hands.yml
+++ b/.github/workflows/hands.yml
@@ -1,0 +1,90 @@
+name: Hands
+
+# `/hands` is a shipped route with a link to it from the editor's topbar, and
+# until now the only thing standing between a regression and the live site was
+# somebody remembering to run `pnpm test:hands` by hand.
+#
+# It is NOT part of the required `ci` check, and that is the whole design.
+# The harness fetches its model weights from storage.googleapis.com — Google
+# publishes no licence for them, so we link rather than host (see AGENTS.md) —
+# which means a required gate here would block every unrelated PR in the repo
+# on someone else's CDN having a good afternoon. A separate workflow gets the
+# signal without handing them a veto: a failure shows as a red X on the PR,
+# a human reads it, and the merge button still works.
+#
+# To make it blocking later, add "hands" to the required checks in the
+# `protect-main` ruleset. Nothing here needs to change for that.
+#
+# The two path lists below are identical and are written out twice on purpose:
+# GitHub Actions does not support YAML anchors, so `&x` / `*x` parses fine in
+# every local linter and then silently fails to mean anything here.
+
+on:
+  pull_request:
+    paths:
+      # The page and its gesture vocabulary.
+      - 'apps/editor/src/harness/**'
+      - 'apps/editor/hands/**'
+      # How it is served and built — the wasm middleware lives here.
+      - 'apps/editor/vite.config.ts'
+      # The harness itself, and the vendoring step it depends on.
+      - 'tools/hands-check.mjs'
+      - 'tools/hands-assets.mjs'
+      - 'tools/harness.mjs'
+      # Every gesture lands on a library feature. A change to the cloth sim,
+      # a deformer or the schema is exactly what breaks a gesture silently,
+      # so those changes are the ones most worth running this on.
+      - 'packages/paperlab/src/**'
+      - '.github/workflows/hands.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/editor/src/harness/**'
+      - 'apps/editor/hands/**'
+      - 'apps/editor/vite.config.ts'
+      - 'tools/hands-check.mjs'
+      - 'tools/hands-assets.mjs'
+      - 'tools/harness.mjs'
+      - 'packages/paperlab/src/**'
+      - '.github/workflows/hands.yml'
+  # Google ships new model revisions and MediaPipe ships new releases on their
+  # own schedule, neither of which touches this repo. Monday morning catches
+  # that drift before a visitor does.
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: hands-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  hands:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      # Scripted hands, not a webcam: `__HANDS__.drive()` takes a timestamp so
+      # the gestures can be driven frame-exact. The camera is still started
+      # once for real, against Chromium's fake device, because that is the only
+      # way the assertions about WHERE the wasm and the models come from mean
+      # anything. `hands:setup` runs inside the harness, so it is not a step.
+      - name: Gestures reach the paper
+        run: pnpm test:hands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,7 +559,7 @@ pnpm knip           # dead code and unused exports
 | `pnpm test:drive` | the editor | the stage really walks when you drag, wheel or arrow it. **CI gate** |
 | `pnpm test:share` | the editor | sculpt → copy a link → open it in a browser that has never seen the paper. **CI gate** |
 | `pnpm test:dropdown` | the editor | every option list is reachable — including the ones below the fold. **CI gate** |
-| `pnpm test:hands` | `/hands` | scripted gestures really reach the paper — grab, score, paint, tear, crush, blow, pointer capture, and that the page talks to nobody. Runs `pnpm hands:setup` for you |
+| `pnpm test:hands` | `/hands` | scripted gestures really reach the paper — grab, score, paint, tear, crush, blow, pointer capture, and that the page talks to nobody. Runs `pnpm hands:setup` for you. **Own workflow**, not the `ci` gate — see below |
 | `pnpm test:route` | `tools/site-root.html` | the site root sends desktops to the editor and everything else to the playground, and its nav names every route `pages.yml` deploys. **CI gate** |
 | `pnpm perf` / `perf:field` | `stage.html` / `field.html` | frame cost. `--gpu` for the platform GPU, `--soft` for the SwiftShader floor |
 | `pnpm shot` / `shot:ui` / `shot:play` / `shot:light` | stage, editor, playground, one rig | PNGs into `.shots/` |
@@ -572,6 +572,16 @@ without either for its first weeks, deployed and unreachable, which is why
 signpost does not name one. It is never a redirect TARGET: it wants a camera
 and two model files before it does anything, so it is somewhere you choose to
 go, not somewhere you are sent.
+
+**It has CI, and deliberately not the required kind.** `.github/workflows/hands.yml`
+runs `pnpm test:hands` on the paths that can break it — the harness, the page,
+the vite wiring, and `packages/paperlab/src/**`, because every gesture lands on
+a library feature and a change to the cloth sim is exactly what breaks one
+silently — plus weekly, to catch a MediaPipe or model revision that no commit
+here caused. It is NOT in `protect-main`'s required checks: the harness fetches
+its weights from Google, and a required gate would let someone else's CDN block
+every unrelated PR in the repo. A failure is a red X somebody reads, not a veto.
+Adding `hands` to the ruleset is all it would take to change that.
 
 **Run `pnpm hands:setup` before the page will start.** The tracker's wasm is
 served from our own origin — it is executable code in a page holding a camera

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ pnpm knip           # dead code and unused exports
 pnpm build
 ```
 
-Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All of them but `test:hands` are CI gates, along with `publint` and `are-the-types-wrong` on the published package — `test:hands` fetches its models from Google, so it is run by hand rather than made to speak for someone else's uptime.
+Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All of them but `test:hands` are CI gates, along with `publint` and `are-the-types-wrong` on the published package. `test:hands` runs in [its own workflow](.github/workflows/hands.yml) instead — on the paths that can break it, and weekly — because it fetches its models from Google and a required gate would let someone else's CDN block every unrelated PR. A red X you have to read, rather than a veto.
 
 ### Measurement
 

--- a/packages/paperlab/README.md
+++ b/packages/paperlab/README.md
@@ -244,7 +244,7 @@ pnpm knip           # dead code and unused exports
 pnpm build
 ```
 
-Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All of them but `test:hands` are CI gates, along with `publint` and `are-the-types-wrong` on the published package — `test:hands` fetches its models from Google, so it is run by hand rather than made to speak for someone else's uptime.
+Anything that needs a real GPU, real pointer events or a second browser profile is a browser harness in `tools/` rather than a unit test. All of them but `test:hands` are CI gates, along with `publint` and `are-the-types-wrong` on the published package. `test:hands` runs in [its own workflow](https://github.com/NourMtir0722/Paperlab/blob/main/.github/workflows/hands.yml) instead — on the paths that can break it, and weekly — because it fetches its models from Google and a required gate would let someone else's CDN block every unrelated PR. A red X you have to read, rather than a veto.
 
 ### Measurement
 

--- a/tools/hands-check.mjs
+++ b/tools/hands-check.mjs
@@ -683,10 +683,7 @@ try {
   // instant the sheet is WIDE and hands the drape check a sheet that has not
   // re-draped yet — which is how the first version of this reported the sim
   // snapping flat on CI while it was merely mid-rebuild.
-  const resized = await until(
-    extent,
-    (e) => e.x > draped.x * 1.4 && e.z > draped.z * grown.scale * 0.5,
-  )
+  const resized = await until(extent, (e) => e.x > draped.x * 1.4 && e.z > draped.z * grown.scale * 0.5)
   await release()
 
   // ── Resize, as a shape. The case that was always free. ───────────────────

--- a/tools/hands-check.mjs
+++ b/tools/hands-check.mjs
@@ -617,9 +617,10 @@ try {
     for (let i = 0; i < 80; i++) last = window.__HANDS__.drive(null, a, { pucker: 1 })
     return last.wind
   }, ASPECT)
-  await page.waitForTimeout(900)
-  const blownShape = await vertices()
-  const blown = moved(stillShape, blownShape)
+  const blown = await until(
+    async () => moved(stillShape, await vertices()),
+    (distance) => distance > 0.02,
+  )
   const calmed = await page.evaluate((a) => {
     let last
     for (let i = 0; i < 80; i++) last = window.__HANDS__.drive(null, a, null)
@@ -678,7 +679,14 @@ try {
   // span, then three at the new width — one rebuild, not twelve.
   await spread(0.3, 5, false)
   const grown = await spread(0.6, 3, false)
-  const resized = await until(extent, (e) => e.x > draped.x * 1.4)
+  // Both halves of what `resized` is asked to prove, or this returns the
+  // instant the sheet is WIDE and hands the drape check a sheet that has not
+  // re-draped yet — which is how the first version of this reported the sim
+  // snapping flat on CI while it was merely mid-rebuild.
+  const resized = await until(
+    extent,
+    (e) => e.x > draped.x * 1.4 && e.z > draped.z * grown.scale * 0.5,
+  )
   await release()
 
   // ── Resize, as a shape. The case that was always free. ───────────────────

--- a/tools/hands-check.mjs
+++ b/tools/hands-check.mjs
@@ -45,6 +45,15 @@ const PORT = 5187
  * going to fail anyway, and the job's own timeout is the real backstop.
  */
 const SETTLE_MS = 150_000
+/**
+ * How long to let a gesture's CONSEQUENCE arrive before calling it absent.
+ *
+ * Shorter than SETTLE_MS on purpose: this is not waiting for a sheet to fall
+ * quiet, it is waiting for a rebuild or a throw that a working page does in a
+ * handful of frames. If one has not landed in half a minute it is broken, not
+ * slow, and the check should say so.
+ */
+const CATCH_UP_MS = 30_000
 /** Wind off: something is trying to measure a drag, and wind is noise. */
 const URL_PATH = '/hands/?wind=0'
 const ASPECT = 4 / 3
@@ -284,6 +293,32 @@ try {
   }
 
   await settle()
+
+  /**
+   * Read until the reading is the one being waited for, then return it.
+   *
+   * This replaces `waitForTimeout(n)` immediately followed by a measurement.
+   * Those numbers were wall-clock stand-ins for "the sim has caught up", and
+   * they were tuned by watching one machine: the sheet needs a number of
+   * FRAMES to rebuild at a new size or to fall off its pins, and how long
+   * those take is the renderer's business. A CI runner got 160 ms of a slower
+   * clock, measured a sheet that had not moved yet, and reported three
+   * unrelated gestures as broken while the gesture layer was reading them
+   * perfectly — the resize even computed its 1.64x correctly.
+   *
+   * It does NOT weaken anything. The deadline is a ceiling, not a pass: a
+   * thing that never happens still fails, and the last reading is returned
+   * either way so the check prints the number it actually saw.
+   */
+  const until = async (read, done, ms = CATCH_UP_MS) => {
+    const deadline = Date.now() + ms
+    let value = await read()
+    while (!done(value) && Date.now() < deadline) {
+      await page.waitForTimeout(100)
+      value = await read()
+    }
+    return value
+  }
 
   /** Sweep FROM → TO holding one pose, returning how far the sheet moved. */
   const sweep = async (pose) => {
@@ -643,8 +678,7 @@ try {
   // span, then three at the new width — one rebuild, not twelve.
   await spread(0.3, 5, false)
   const grown = await spread(0.6, 3, false)
-  await page.waitForTimeout(160)
-  const resized = await extent()
+  const resized = await until(extent, (e) => e.x > draped.x * 1.4)
   await release()
 
   // ── Resize, as a shape. The case that was always free. ───────────────────
@@ -657,8 +691,7 @@ try {
   const crushedBig = await extent()
   await spread(0.6, 5, false)
   const shrunk = await spread(0.3, 3, false)
-  await page.waitForTimeout(300)
-  const crushedSmall = await extent()
+  const crushedSmall = await until(extent, (e) => e.x < crushedBig.x * 0.75)
   await release()
 
   // ── Peel. A pinch that lands on a CORNER curls it instead of dragging it. ─
@@ -707,8 +740,10 @@ try {
     },
     [POSES, ASPECT],
   )
-  await page.waitForTimeout(1400)
-  const flew = moved(hanging, await vertices())
+  const flew = await until(
+    async () => moved(hanging, await vertices()),
+    (distance) => distance > 0.3,
+  )
 
   // Sanity: the scripted hand really is on the two sides of the threshold,
   // and the gesture layer names each pose the way the unit tests say it does.

--- a/tools/hands-check.mjs
+++ b/tools/hands-check.mjs
@@ -28,6 +28,23 @@ import { rendererArgs, startApp } from './harness.mjs'
 import { ensureHandsAssets } from './hands-assets.mjs'
 
 const PORT = 5187
+/**
+ * How long to wait for the cloth to stop moving.
+ *
+ * This is a WALL-CLOCK number guarding a FRAME-DRIVEN simulation, which is
+ * the whole reason it needs saying out loud. The sheet comes to rest after
+ * roughly the same number of steps everywhere; how long that takes is
+ * whatever the machine's renderer can manage. This harness has run in a
+ * 65-second pass on a laptop and an 11-minute one under `--soft` on the same
+ * laptop — same SwiftShader, ten times the wall clock — and a CI runner sits
+ * somewhere in between. 30 seconds was enough for the first and not the
+ * second, which is not a fact about the sim.
+ *
+ * So it is generous on purpose. Nothing waits the full duration when the
+ * sheet settles promptly; the number only costs anything on the run that was
+ * going to fail anyway, and the job's own timeout is the real backstop.
+ */
+const SETTLE_MS = 150_000
 /** Wind off: something is trying to measure a drag, and wind is noise. */
 const URL_PATH = '/hands/?wind=0'
 const ASPECT = 4 / 3
@@ -236,20 +253,35 @@ try {
    * settles is the sim's own motion wearing the result's clothes — and the
    * edge scan further down needs a sheet that is where it is going to stay.
    */
-  const settle = () =>
-    page.waitForFunction(
-      () => {
-        const now = window.__HANDS__.vertices()
-        const before = window.__SETTLE__
-        window.__SETTLE__ = now
-        if (!before || before.length !== now.length) return false
-        let max = 0
-        for (let i = 0; i < now.length; i++) max = Math.max(max, Math.abs(now[i] - before[i]))
-        return max < 1e-4
-      },
-      null,
-      { timeout: 30_000, polling: 250 },
-    )
+  const settle = async () => {
+    try {
+      await page.waitForFunction(
+        () => {
+          const now = window.__HANDS__.vertices()
+          const before = window.__SETTLE__
+          window.__SETTLE__ = now
+          if (!before || before.length !== now.length) return false
+          let max = 0
+          for (let i = 0; i < now.length; i++) max = Math.max(max, Math.abs(now[i] - before[i]))
+          window.__SETTLE_MAX__ = max
+          return max < 1e-4
+        },
+        null,
+        { timeout: SETTLE_MS, polling: 250 },
+      )
+    } catch {
+      // A bare Playwright TimeoutError names the line and nothing else, which
+      // on a machine you cannot attach a debugger to is one round trip per
+      // question. Say how close it got instead: a max still far above the
+      // threshold means the sheet is genuinely in motion, and a max hovering
+      // just above it means this wait is short rather than the sim broken.
+      const max = await page.evaluate(() => window.__SETTLE_MAX__ ?? Number.NaN)
+      throw new Error(
+        `the sheet never came to rest: still moving ${max.toExponential(2)} per poll after ` +
+          `${SETTLE_MS / 1000}s (needs < 1e-4). Slower hardware needs longer — raise SETTLE_MS.`,
+      )
+    }
+  }
 
   await settle()
 


### PR DESCRIPTION
Follow-up to #77, closing the open question it left.

`/hands` is now a linked, official surface — the editor's topbar points at it — and the only thing between a regression and the live site was somebody remembering to run `pnpm test:hands`. The harness is thorough: thirteen gestures, pointer capture, and the assertions that the page reaches no third-party origin but the model host and never MediaPipe's telemetry endpoint. It just never ran on its own.

## The design: its own workflow, not a step in `ci`

The harness fetches its model weights from `storage.googleapis.com`, because Google publishes no licence for them and we link rather than redistribute (AGENTS.md has the reasoning). Putting that in the required `ci` check would hand a Google CDN wobble a veto over every unrelated PR in this repo — a dependency-bump PR blocked on a model host is how a gate teaches people to merge past it.

So `.github/workflows/hands.yml` runs it separately. A failure is a **red X somebody reads**, not a blocked merge. Making it blocking later is one line — add `hands` to the required checks in the `protect-main` ruleset — and nothing in the file changes.

## Triggers

The paths that can actually break it:

- `apps/editor/src/harness/**`, `apps/editor/hands/**` — the page and the gesture vocabulary
- `apps/editor/vite.config.ts` — the middleware that serves its wasm
- `tools/hands-check.mjs`, `tools/hands-assets.mjs`, `tools/harness.mjs`
- `packages/paperlab/src/**` — every gesture lands on a library feature, and a change to the cloth sim or a deformer is exactly what breaks one silently
- Weekly (Mon 07:00), to catch a MediaPipe or model revision that no commit here caused

## One thing worth knowing

The two path lists are identical and written out twice on purpose. **GitHub Actions does not support YAML anchors** — `&x`/`*x` parses clean in every local linter and then silently means nothing. The first draft of this file had the anchor and a passing local YAML check; it would have shipped a workflow whose `push` trigger did nothing.

## Verification

- YAML parses; both path lists confirmed identical (8 entries each); job and step structure checked
- `pnpm lint` clean, docs tests pass (54)
- `pnpm test:hands` green locally against this tree — 65s, camera live, models fetched, telemetry blocked by the CSP
- `packages/paperlab/README.md` regenerated so CI's "Generated files are up to date" stays green; the relative workflow link correctly rewrites to an absolute URL for npm

README and AGENTS.md both said `test:hands` was run by hand. That stops being true with this commit, so both are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Hands harness testing for relevant pull requests, pushes to the main branch, weekly runs, and manual launches.
  - Tests now install required browser tooling and run with isolated, cancelable workflow executions.

- **Documentation**
  - Updated project documentation to explain the dedicated Hands workflow, its scheduled and path-based triggers, external model requirements, and non-blocking status.
  - Clarified that other browser harnesses remain required CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->