### PR TITLE
chore(deps): move to zod 4

### DIFF
--- a/.changeset/zod-four.md
+++ b/.changeset/zod-four.md
@@ -1,0 +1,22 @@
+---
+'paperlab': minor
+---
+
+Move to zod 4.
+
+`zod` is a runtime dependency of this package and its schemas are part of the
+public API — `paperConfigSchema`, `sceneSchema`, `paperStatesSchema` and
+`stageSchema` are all exported — so the major version is part of what Paperlab
+promises. Anyone composing those schemas into their own zod 3 tree will need
+to move too; anyone calling `.parse()` on them is unaffected.
+
+The `.paper` file format does NOT change. Every built-in preset, every stage
+preset and the empty-object case for all four exported schemas were parsed
+under both versions and diffed: byte-identical, 1095 lines.
+
+That check was the point rather than a formality. zod 4 redefines `.default()`
+to short-circuit — it hands back the literal value instead of parsing it — so
+the sixteen `schema.default({})` calls that fill in nested defaults would have
+silently started producing `{}`. They are `.prefault({})` now, which is the
+old behaviour under its new name, and nothing about that is visible to a
+typecheck.

--- a/.changeset/zod-four.md
+++ b/.changeset/zod-four.md
@@ -8,7 +8,10 @@ Move to zod 4.
 public API — `paperConfigSchema`, `sceneSchema`, `paperStatesSchema` and
 `stageSchema` are all exported — so the major version is part of what Paperlab
 promises. Anyone composing those schemas into their own zod 3 tree will need
-to move too; anyone calling `.parse()` on them is unaffected.
+to move too. Calling `.parse()` on them is unchanged in what it returns and what
+it accepts — but zod 4 reshaped the error it throws, so anyone READING a
+`ZodError` off these schemas rather than just letting it throw has a change to
+make.
 
 The `.paper` file format does NOT change. Every built-in preset, every stage
 preset and the empty-object case for all four exported schemas were parsed

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "three": "^0.185.1",
-    "zod": "^3.24.0"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/node": "^26.3.0",

--- a/apps/docs/src/schemaDoc.test.ts
+++ b/apps/docs/src/schemaDoc.test.ts
@@ -43,6 +43,22 @@ describe('describeSchema', () => {
     expect(row(rows, 'edges')).toMatchObject({ type: 'list', fallback: "['bottom']" })
     expect(row(rows, 'state')).toMatchObject({ type: 'object', fallback: '{}' })
   })
+
+  it('reads a .prefault() field as the object it wraps', () => {
+    // The library's nested schemas are all `.prefault({})` under zod 4, so a
+    // walk that only knows `.default()` documents each of them as an opaque
+    // 'value' with no keys and no fallback.
+    const rows = describeSchema(
+      z.object({
+        path: z.object({ closed: z.boolean().default(false), seed: z.number().default(1) }).prefault({}),
+      }),
+    )
+    expect(row(rows, 'path')).toMatchObject({
+      type: 'object',
+      options: ['closed', 'seed'],
+      fallback: '{}',
+    })
+  })
 })
 
 /**

--- a/apps/docs/src/schemaDoc.ts
+++ b/apps/docs/src/schemaDoc.ts
@@ -25,11 +25,11 @@ export interface ParamDoc {
   fallback?: string
 }
 
-export function describeSchema(schema: z.ZodTypeAny): ParamDoc[] {
+export function describeSchema(schema: z.ZodType): ParamDoc[] {
   if (!(schema instanceof z.ZodObject)) return []
   const rows: ParamDoc[] = []
 
-  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodTypeAny>)) {
+  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodType>)) {
     // `type` is the discriminator a preset needs, not a parameter anyone tunes.
     if (key === 'type') continue
     const fallback = defaultOf(field)
@@ -44,7 +44,7 @@ export function describeSchema(schema: z.ZodTypeAny): ParamDoc[] {
     } else if (inner instanceof z.ZodString) {
       rows.push({ key, type: 'text', fallback })
     } else if (inner instanceof z.ZodTuple) {
-      const items = inner._def.items as z.ZodTypeAny[]
+      const items = inner.def.items as z.ZodType[]
       rows.push({ key, type: `vector (${items.length})`, fallback })
     } else if (inner instanceof z.ZodArray) {
       rows.push({ key, type: 'list', fallback })
@@ -64,12 +64,15 @@ function rangeOf(num: z.ZodNumber): string | undefined {
   return `${min ?? '−∞'} – ${max ?? '∞'}`
 }
 
-function defaultOf(field: z.ZodTypeAny): string | undefined {
+function defaultOf(field: z.ZodType): string | undefined {
   let f = field
-  while (f instanceof z.ZodOptional) f = f.unwrap()
+  while (f instanceof z.ZodOptional) f = f.unwrap() as z.ZodType
   if (!(f instanceof z.ZodDefault)) return undefined
   try {
-    return render(f._def.defaultValue())
+    // zod 3 kept this behind a thunk (`defaultValue()`); zod 4 stores the
+    // value itself. Calling it here would throw on every field and this
+    // whole column would quietly render empty.
+    return render(f.def.defaultValue)
   } catch {
     return undefined
   }
@@ -88,15 +91,25 @@ function render(value: unknown): string {
   return String(value)
 }
 
-function unwrap(field: z.ZodTypeAny): z.ZodTypeAny {
+function unwrap(field: z.ZodType): z.ZodType {
   let f = field
   while (f instanceof z.ZodDefault || f instanceof z.ZodOptional) {
-    f = f instanceof z.ZodDefault ? f._def.innerType : f.unwrap()
+    f = f.unwrap() as z.ZodType
   }
   return f
 }
 
+/**
+ * A bound, off zod 4's accessor rather than out of `_def.checks`.
+ *
+ * The old walk type-checked clean against zod 4 and returned `undefined` for
+ * every bound, which would have published a reference with the range column
+ * blank on every numeric parameter.
+ */
 function checkValue(num: z.ZodNumber, kind: 'min' | 'max'): number | undefined {
-  const check = num._def.checks.find((c) => c.kind === kind)
-  return check && 'value' in check ? (check.value as number) : undefined
+  const bound = kind === 'min' ? num.minValue : num.maxValue
+  // An UNBOUNDED number reads ±Infinity here, where zod 3's empty check list
+  // read as absent. `?? undefined` does not catch it — Infinity is not
+  // nullish — and an Infinity reaching a slider is a track with no ends.
+  return Number.isFinite(bound) ? (bound as number) : undefined
 }

--- a/apps/docs/src/schemaDoc.ts
+++ b/apps/docs/src/schemaDoc.ts
@@ -67,7 +67,10 @@ function rangeOf(num: z.ZodNumber): string | undefined {
 function defaultOf(field: z.ZodType): string | undefined {
   let f = field
   while (f instanceof z.ZodOptional) f = f.unwrap() as z.ZodType
-  if (!(f instanceof z.ZodDefault)) return undefined
+  // Both wrappers store the value the same way (`def.defaultValue`); they
+  // differ only in whether it is parsed on the way through, which is not
+  // something a docs table can show.
+  if (!(f instanceof z.ZodDefault || f instanceof z.ZodPrefault)) return undefined
   try {
     // zod 3 kept this behind a thunk (`defaultValue()`); zod 4 stores the
     // value itself. Calling it here would throw on every field and this
@@ -93,7 +96,9 @@ function render(value: unknown): string {
 
 function unwrap(field: z.ZodType): z.ZodType {
   let f = field
-  while (f instanceof z.ZodDefault || f instanceof z.ZodOptional) {
+  // `.prefault()` too — see the editor walker's note. Same wrapper, and this
+  // is its read-only twin.
+  while (f instanceof z.ZodDefault || f instanceof z.ZodPrefault || f instanceof z.ZodOptional) {
     f = f.unwrap() as z.ZodType
   }
   return f

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "three": "^0.185.1",
-    "zod": "^3.24.0",
+    "zod": "^4.5.4",
     "zustand": "^5.0.15"
   },
   "devDependencies": {

--- a/apps/editor/src/controls/controlModel.test.ts
+++ b/apps/editor/src/controls/controlModel.test.ts
@@ -96,6 +96,31 @@ describe('schemaControls', () => {
     expect(edits).toEqual([['figure', { height: 2, visible: true }]])
   })
 
+  it('sees through .prefault() to the nested object, the way it does through .default()', () => {
+    // Every nested schema in the library is `.prefault({})` since zod 4 —
+    // that is what zod 3's `.default({})` meant. The walk has to unwrap it
+    // or the stage inspector loses a folder per prefaulted field, with a
+    // green typecheck and no error anywhere.
+    const schema = z.object({
+      figure: z
+        .object({ height: z.number().min(1).max(3).default(1.7), visible: z.boolean().default(true) })
+        .prefault({}),
+    })
+    const edits: [string, unknown][] = []
+    const controls = schemaControls(schema, { figure: { height: 1.7, visible: true } }, (k, v) =>
+      edits.push([k, v]),
+    )
+
+    const figure = byKey(controls, 'figure')
+    if (figure.kind !== 'folder') throw new Error('expected folder')
+
+    const height = byKey(figure.children, 'height')
+    if (height.kind !== 'number') throw new Error('expected number')
+    expect(height.min).toBe(1)
+    height.onChange(2)
+    expect(edits).toEqual([['figure', { height: 2, visible: true }]])
+  })
+
   it('keeps duplicate leaf names apart in sibling folders (the leva flatten bug this model retires)', () => {
     // A stage whose shot and figure both carry `height` used to lose one
     // silently — the tree keeps hierarchy, so both survive.

--- a/apps/editor/src/controls/controlModel.test.ts
+++ b/apps/editor/src/controls/controlModel.test.ts
@@ -245,7 +245,7 @@ describe('numberSpec', () => {
         const emitted = spec.snap(raw)
         expect(
           () => schema.parse(emitted),
-          `${JSON.stringify(schema._def.checks)} rejected ${emitted} (from ${raw})`,
+          `${JSON.stringify({ min: schema.minValue, max: schema.maxValue, format: schema.format })} rejected ${emitted} (from ${raw})`,
         ).not.toThrow()
       }
     }

--- a/apps/editor/src/controls/controlModel.ts
+++ b/apps/editor/src/controls/controlModel.ts
@@ -193,7 +193,7 @@ export function emphasize(controls: Control[], emphasis: Emphasis = 'signature')
  * `windY`, `windZ` and none of those is the name the behavior nominated.
  */
 export function partitionSignature(
-  schema: z.ZodTypeAny,
+  schema: z.ZodType,
   signature: readonly string[] | undefined,
   values: Record<string, unknown>,
   onChange: (key: string, value: unknown) => void,
@@ -201,7 +201,7 @@ export function partitionSignature(
   if (!(schema instanceof z.ZodObject) || !signature?.length) {
     return { signature: [], rest: schemaControls(schema, values, onChange) }
   }
-  const keys = Object.keys(schema.shape as Record<string, z.ZodTypeAny>)
+  const keys = Object.keys(schema.shape as Record<string, z.ZodType>)
   const nominated = signature.filter((key) => keys.includes(key))
   return {
     signature: emphasize(
@@ -241,7 +241,7 @@ const COLOR = 'color'
  * well-formed value.
  */
 export function schemaControls(
-  schema: z.ZodTypeAny,
+  schema: z.ZodType,
   values: Record<string, unknown>,
   onChange: (key: string, value: unknown) => void,
   skip: string[] = [],
@@ -249,7 +249,7 @@ export function schemaControls(
   if (!(schema instanceof z.ZodObject)) return []
   const controls: Control[] = []
 
-  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodTypeAny>)) {
+  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodType>)) {
     if (skip.includes(key)) continue
     const inner = unwrap(field)
     const value = values[key]
@@ -258,7 +258,7 @@ export function schemaControls(
       controls.push(numberControl(key, key, inner, value, (v) => onChange(key, v)))
     } else if (inner instanceof z.ZodTuple && isNumberTuple(inner)) {
       // Numeric tuples (flight's wind vector) → one slider per component.
-      const items = inner._def.items as z.ZodNumber[]
+      const items = inner.def.items as z.ZodNumber[]
       const current = Array.isArray(value) ? (value as number[]) : items.map(() => 0)
       items.forEach((item, axis) => {
         controls.push(
@@ -277,7 +277,7 @@ export function schemaControls(
         )
       })
     } else if (inner instanceof z.ZodEnum) {
-      controls.push(select(key, String(value), [...inner.options], (v) => onChange(key, v)))
+      controls.push(select(key, String(value), inner.options.map(String), (v) => onChange(key, v)))
     } else if (inner instanceof z.ZodBoolean) {
       controls.push(toggle(key, Boolean(value), (v) => onChange(key, v)))
     } else if (inner instanceof z.ZodString) {
@@ -338,7 +338,7 @@ export interface NumberSpec {
 }
 
 export function numberSpec(schema: z.ZodNumber, fallbackMin = 0): NumberSpec {
-  const integer = schema._def.checks.some((c) => c.kind === 'int')
+  const integer = schema.format === 'safeint'
   const rawMin = checkValue(schema, 'min') ?? fallbackMin
   const rawMax = checkValue(schema, 'max') ?? 1
   const step = integer ? 1 : (rawMax - rawMin) / 200
@@ -372,30 +372,43 @@ function numberControl(
  * draw their own markup rather than going through `Control` — they still do
  * not get to re-derive what the schema allows.
  */
-export function numericFields(schema: z.ZodTypeAny): { key: string; spec: NumberSpec }[] {
+export function numericFields(schema: z.ZodType): { key: string; spec: NumberSpec }[] {
   if (!(schema instanceof z.ZodObject)) return []
   const out: { key: string; spec: NumberSpec }[] = []
-  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodTypeAny>)) {
+  for (const [key, field] of Object.entries(schema.shape as Record<string, z.ZodType>)) {
     const inner = unwrap(field)
     if (inner instanceof z.ZodNumber) out.push({ key, spec: numberSpec(inner) })
   }
   return out
 }
 
+/**
+ * Was the bound written `.gt()`/`.lt()` rather than `.min()`/`.max()`?
+ *
+ * `minValue` and `maxValue` report the number either way, so this is the one
+ * thing still read off the check list. zod 4 names them `greater_than` and
+ * `less_than` and carries `inclusive` beside the value.
+ */
 function isExclusive(schema: z.ZodNumber, kind: 'min' | 'max'): boolean {
-  const check = schema._def.checks.find((c) => c.kind === kind)
-  return Boolean(check && 'inclusive' in check && check.inclusive === false)
+  const want = kind === 'min' ? 'greater_than' : 'less_than'
+  const checks = (schema as unknown as ZodInternals)._zod?.def?.checks ?? []
+  return checks.some((c) => c._zod?.def?.check === want && c._zod?.def?.inclusive === false)
+}
+
+/** The sliver of zod 4's internals this file still has to name. */
+interface ZodInternals {
+  _zod?: { def?: { checks?: { _zod?: { def?: { check?: string; inclusive?: boolean } } }[] } }
 }
 
 function isNumberTuple(tuple: z.ZodTuple): boolean {
-  const items = tuple._def.items as z.ZodTypeAny[]
+  const items = tuple.def.items as z.ZodType[]
   return items.length > 0 && items.length <= 4 && items.every((i) => i instanceof z.ZodNumber)
 }
 
-function unwrap(field: z.ZodTypeAny): z.ZodTypeAny {
+function unwrap(field: z.ZodType): z.ZodType {
   let f = field
   while (f instanceof z.ZodDefault || f instanceof z.ZodOptional) {
-    f = f instanceof z.ZodDefault ? f._def.innerType : f.unwrap()
+    f = f.unwrap() as z.ZodType
   }
   return f
 }
@@ -408,15 +421,26 @@ function unwrap(field: z.ZodTypeAny): z.ZodTypeAny {
  * own to show — and the range is still the schema's fact to state, not
  * theirs to restate.
  */
-export function numberRange(schema: z.ZodTypeAny, key: string): { min: number; max: number } {
-  const field =
-    schema instanceof z.ZodObject ? (schema.shape as Record<string, z.ZodTypeAny>)[key] : undefined
+export function numberRange(schema: z.ZodType, key: string): { min: number; max: number } {
+  const field = schema instanceof z.ZodObject ? (schema.shape as Record<string, z.ZodType>)[key] : undefined
   const inner = field ? unwrap(field) : undefined
   if (!(inner instanceof z.ZodNumber)) return { min: 0, max: 1 }
   return { min: checkValue(inner, 'min') ?? 0, max: checkValue(inner, 'max') ?? 1 }
 }
 
+/**
+ * A bound, off zod 4's own accessor.
+ *
+ * zod 3 kept these in `_def.checks` as `{ kind: 'min', value }` and this
+ * walked that list. zod 4 exposes `minValue`/`maxValue` directly, so the
+ * internals walk is gone — which matters because that walk type-checked
+ * clean against zod 4 and returned `undefined` for every bound at runtime.
+ * Every slider in the editor would have silently fallen back to 0–1.
+ */
 function checkValue(num: z.ZodNumber, kind: 'min' | 'max'): number | undefined {
-  const check = num._def.checks.find((c) => c.kind === kind)
-  return check && 'value' in check ? check.value : undefined
+  const bound = kind === 'min' ? num.minValue : num.maxValue
+  // An UNBOUNDED number reads ±Infinity here, where zod 3's empty check list
+  // read as absent. `?? undefined` does not catch it — Infinity is not
+  // nullish — and an Infinity reaching a slider is a track with no ends.
+  return Number.isFinite(bound) ? (bound as number) : undefined
 }

--- a/apps/editor/src/controls/controlModel.ts
+++ b/apps/editor/src/controls/controlModel.ts
@@ -407,7 +407,12 @@ function isNumberTuple(tuple: z.ZodTuple): boolean {
 
 function unwrap(field: z.ZodType): z.ZodType {
   let f = field
-  while (f instanceof z.ZodDefault || f instanceof z.ZodOptional) {
+  // `.prefault()` belongs here as much as `.default()` does. It is zod 4's
+  // name for the behaviour zod 3's `.default()` had, so the sixteen nested
+  // schemas this repo moved onto it are wrappers this walk has to see
+  // through — miss it and every one of them stops being a ZodObject here,
+  // which is the stage inspector's folders and the walk layout's path.
+  while (f instanceof z.ZodDefault || f instanceof z.ZodPrefault || f instanceof z.ZodOptional) {
     f = f.unwrap() as z.ZodType
   }
   return f

--- a/apps/editor/src/state/session.ts
+++ b/apps/editor/src/state/session.ts
@@ -60,7 +60,7 @@ const zoneSchema = z.object({
 
 const fieldSessionSchema = z.object({
   layout: z.string(),
-  layoutOptions: z.record(z.unknown()),
+  layoutOptions: z.record(z.string(), z.unknown()),
   count: z.number().int().min(1).max(400),
   driver: z.enum(['autoplay', 'drag', 'none']),
   speed: z.number(),
@@ -76,7 +76,7 @@ const stageSessionSchema = z.object({
   preset: z.string(),
   walk: z.enum(walkNames),
   layout: z.string(),
-  layoutOptions: z.record(z.unknown()),
+  layoutOptions: z.record(z.string(), z.unknown()),
   text: z.string(),
   count: z.number().int().min(1).max(400),
   // The walk is held as a name, so the resolved path is not part of the view.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "three": "^0.185.1",
-    "zod": "^3.24.0"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/node": "^26.3.0",

--- a/apps/playground/src/share.ts
+++ b/apps/playground/src/share.ts
@@ -39,9 +39,9 @@ const shareSchema = z.object({
   t: z.string().max(MAX_TEXT_LENGTH).optional(),
   n: z.number().int().min(1).max(80).optional(),
   l: z.string().optional(),
-  lo: z.record(z.unknown()).optional(),
+  lo: z.record(z.string(), z.unknown()).optional(),
   /** Stage overrides — validated against the real schema on the way out. */
-  s: z.record(z.unknown()).optional(),
+  s: z.record(z.string(), z.unknown()).optional(),
 })
 
 export interface StageShare {

--- a/packages/paperlab/package.json
+++ b/packages/paperlab/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@react-three/drei": "^10.7.8",
     "three-custom-shader-material": "^6.4.0",
-    "zod": "^3.24.0"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",

--- a/packages/paperlab/src/behaviors/types.ts
+++ b/packages/paperlab/src/behaviors/types.ts
@@ -22,7 +22,7 @@ export interface Behavior<O = AnyOptions> {
   id: string
   label: string
   defaults: O
-  optionsSchema: z.ZodType<O, z.ZodTypeDef, unknown>
+  optionsSchema: z.ZodType<O, unknown>
   /** Expand human params to the underlying deformer stack. */
   stack(o: O, sheet: SheetDims): DeformerInstance[]
   /** Transient, time-varying option overrides (idle motion). Never persisted. */

--- a/packages/paperlab/src/config/schema.ts
+++ b/packages/paperlab/src/config/schema.ts
@@ -439,7 +439,7 @@ export type BehaviorConfigInput = z.input<typeof behaviorConfigSchema>
 /** Advanced escape hatch: a raw deformer stack (editing one forks the behavior). */
 export const deformerInstanceSchema = z.object({
   type: z.string(),
-  options: z.record(z.unknown()).default({}),
+  options: z.record(z.string(), z.unknown()).default({}),
   enabled: z.boolean().default(true),
 })
 
@@ -711,9 +711,9 @@ export const stateTransitionSchema = z.object({
 
 export const stateDefSchema = z.object({
   /** Deep-partial override of the paper schema (behavior params, surface, …). */
-  overrides: z.record(z.unknown()).default({}),
+  overrides: z.record(z.string(), z.unknown()).default({}),
   /** Transition INTO this state. */
-  transition: stateTransitionSchema.default({}),
+  transition: stateTransitionSchema.prefault({}),
   /** Chained actions after arriving. v1: 'emit:<event>' only. */
   onEnter: z.array(z.string().regex(/^emit:[\w-]+$/, 'v1 actions are "emit:<event>"')).default([]),
 })
@@ -746,8 +746,8 @@ export const metaSchema = z.object({
 
 export const paperConfigSchema = z
   .object({
-    meta: metaSchema.default({}),
-    sheet: sheetSchema.default({}),
+    meta: metaSchema.prefault({}),
+    sheet: sheetSchema.prefault({}),
     stock: stockSchema.default('printer'),
     content: contentSchema.default({ type: 'blank' }),
     /** A behavior OR a raw deformer stack — if both are present, `deformers` wins (it's the fork). */
@@ -762,9 +762,9 @@ export const paperConfigSchema = z
      * for. `memory: { set: 0 }` is the opt-out, and it is what every sheet in
      * the library did before this shipped.
      */
-    memory: memorySchema.default({}),
+    memory: memorySchema.prefault({}),
     physics: physicsSchema.default('none'),
-    scene: sceneSchema.default({}),
+    scene: sceneSchema.prefault({}),
     onTwos: z.boolean().default(false),
     /** Interaction state machine — overrides-on-base diffs. */
     states: paperStatesSchema.optional(),

--- a/packages/paperlab/src/deformers/types.ts
+++ b/packages/paperlab/src/deformers/types.ts
@@ -36,7 +36,7 @@ export interface Deformer<O = Record<string, unknown>> {
   id: string
   label: string
   defaults: O
-  optionsSchema: z.ZodType<O, z.ZodTypeDef, unknown>
+  optionsSchema: z.ZodType<O, unknown>
   /** Mutate `out` (sheet-local space; flat sheet is the XY plane facing +Z). */
   displace(out: THREE.Vector3, uv: THREE.Vector2, o: O, ctx: DeformerContext): void
   /** GPU path — arrives with field mode. */

--- a/packages/paperlab/src/field/layouts/index.ts
+++ b/packages/paperlab/src/field/layouts/index.ts
@@ -31,7 +31,7 @@ export interface Layout<O = Record<string, unknown>> {
   id: string
   label: string
   defaults: O
-  optionsSchema: z.ZodType<O, z.ZodTypeDef, unknown>
+  optionsSchema: z.ZodType<O, unknown>
   /**
    * `sheet` is the field's paper size. Layouts that arrange by CONTACT —
    * edges meeting, sheets resting on each other — cannot work without it,
@@ -430,7 +430,7 @@ export const rack: Layout<z.infer<typeof rackSchema>> = {
 
 const colonnadeSchema = z.object({
   /** The walk the colonnade is built along — see `stage/path`. */
-  path: walkPathSchema.default({}),
+  path: walkPathSchema.prefault({}),
   /** Half-width of the clear aisle: how far each banner stands off the walk line. */
   aisle: z.number().min(0.2).max(20).default(2.4),
   /** How much that gap opens and closes along the walk. Nothing hung by hand is a corridor. */

--- a/packages/paperlab/src/stage/schema.ts
+++ b/packages/paperlab/src/stage/schema.ts
@@ -184,9 +184,9 @@ export const stageRoomSchema = z.object({
   height: z.number().min(1).max(6).default(2.2),
   color: z.string().default('#171310').describe('color'),
   /** Columns flanking the walk — see `stageColumnsSchema`. */
-  columns: stageColumnsSchema.default({}),
+  columns: stageColumnsSchema.prefault({}),
   /** A wall at the end of the walk with the source in it. */
-  doorway: stageDoorwaySchema.default({}),
+  doorway: stageDoorwaySchema.prefault({}),
 })
 
 /**
@@ -254,9 +254,9 @@ export const stageGradeSchema = z.object({
 })
 
 export const stageSchema = z.object({
-  path: walkPathSchema.default({}),
-  shot: shotSchema.default({}),
-  figure: figureSchema.default({}),
+  path: walkPathSchema.prefault({}),
+  shot: shotSchema.prefault({}),
+  figure: figureSchema.prefault({}),
   /** Stage mode is built for `nave`; the others are all front-lit. */
   lighting: z.enum(lightingNames).default('nave'),
   /**
@@ -283,12 +283,12 @@ export const stageSchema = z.object({
    * Still one flag away for anyone who wants it.
    */
   showFigure: z.boolean().default(false),
-  source: stageSourceSchema.default({}),
-  ground: stageGroundSchema.default({}),
+  source: stageSourceSchema.prefault({}),
+  ground: stageGroundSchema.prefault({}),
   /** Ceiling and the architecture around the walk — see `stageRoomSchema`. */
-  room: stageRoomSchema.default({}),
+  room: stageRoomSchema.prefault({}),
   /** Thread and clips — see `stageSuspensionSchema`. */
-  suspension: stageSuspensionSchema.default({}),
+  suspension: stageSuspensionSchema.prefault({}),
   /**
    * The print — bloom, vignette, grain.
    *
@@ -300,7 +300,7 @@ export const stageSchema = z.object({
    * behaviour: a stage silently losing its grade would be worse than a
    * missing-module error that names the package.
    */
-  grade: stageGradeSchema.default({}),
+  grade: stageGradeSchema.prefault({}),
 })
 
 export type StageConfig = z.infer<typeof stageSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: ^0.185.1
         version: 0.185.1
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@types/node':
         specifier: ^26.3.0
@@ -117,8 +117,8 @@ importers:
         specifier: ^0.185.1
         version: 0.185.1
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.5.4
+        version: 4.5.4
       zustand:
         specifier: ^5.0.15
         version: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -181,8 +181,8 @@ importers:
         specifier: ^0.185.1
         version: 0.185.1
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@types/node':
         specifier: ^26.3.0
@@ -218,8 +218,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0(@react-three/fiber@9.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1))(react@19.2.8)(three@0.185.1)
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.5
@@ -2220,11 +2220,11 @@ packages:
     resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
     engines: {node: '>=10'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -3909,9 +3909,9 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 20.2.9
 
-  zod@3.25.76: {}
-
   zod@4.4.3: {}
+
+  zod@4.5.4: {}
 
   zustand@4.5.7(@types/react@19.2.18)(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Supersedes #76, which bumped the version and left thirty type errors. **The bump is four lines; the migration is the rest.**

## The file format was the thing at risk

zod 4 redefines `.default()`: it short-circuits and hands back the literal value instead of parsing it. The old behaviour — feed the value in as *input* and parse it, so nested defaults fill in — is now `.prefault()`. Proven before touching anything:

```
zod4 .default({})  → {"x":{}}
zod4 .prefault({}) → {"x":{"a":"A","b":7}}
```

Sixteen `schema.default({})` calls in this repo exist to fill in nested defaults, and **the schema is the `.paper` format**. A mechanical bump would have had every one of them producing `{}` — under a completely green typecheck.

So the check that matters: every built-in preset, every stage preset, and the empty-object case for all four exported schemas, parsed under both versions and diffed. **1095 lines, byte-identical**, re-checked after the final edit.

## Internals that type-check and lie

`controlModel.ts` and `schemaDoc.ts` read `_def.checks`, `_def.items`, `_def.innerType`. Against zod 4 those **type-check clean** — `ZodTypeAny` survives as a loose type — and return `undefined` at runtime. Every slider in the editor would have fallen back to 0–1 and the reference would have published a blank range column, with `tsc` perfectly happy.

Twelve editor tests and four docs tests caught it. Nothing else would have.

Both files now use the public accessors — `minValue`/`maxValue`, `.unwrap()`, `.def.defaultValue`, `.format === 'safeint'` — so they touch no internals beyond one narrow read for `.gt()`/`.lt()` exclusivity, which the accessors genuinely don't carry.

A third, found by the suite: zod 4 reports `±Infinity` for an unbounded number where zod 3's empty check-list read as absent. `?? undefined` doesn't catch it (Infinity isn't nullish), and an Infinity reaching a slider is a track with no ends. Guarded on finiteness.

## The rest

| Pattern | Sites |
|---|---|
| `z.ZodType<O, z.ZodTypeDef, unknown>` → `z.ZodType<O, unknown>` | 3 registries |
| `z.record(z.unknown())` → `z.record(z.string(), z.unknown())` | 6 |
| `.default({})` → `.prefault({})` | 16 |
| enum `.options` is `EnumValue[]`, narrowed at the string-select boundary | 1 |

## Verification

lint · typecheck · knip · build · publint+attw · **1042 tests** · parity · drive · share · dropdown · **hands (41 checks)** — all green locally.

## Note on the public API

`zod` is a runtime `dependencies` of `paperlab` and its schemas are exported (`paperConfigSchema`, `sceneSchema`, `paperStatesSchema`, `stageSchema`), so the major version is part of what this package promises. The changeset is a **minor** and says so: anyone composing those schemas into their own zod 3 tree has to move too; anyone calling `.parse()` on them is unaffected.

Doing this pre-launch is deliberate — it is cheap now and expensive once anyone has forked.

**#76 should be closed rather than merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Migrated Paperlab, Editor, Documentation, and Playground integrations to Zod 4.
  - Consumers composing Paperlab’s exported schemas must also use Zod 4; callers using `.parse()` remain unaffected.
  - Existing `.paper` files remain unchanged and compatible.

- **Schema Handling**
  - Preserved prior default-value parsing behavior.
  - Improved schema documentation and editor controls for numeric limits, tuples, enums, and optional fields.
  - Record-based configuration values now require string keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->